### PR TITLE
Add fsPromise.readdir with minimal implementation for file types

### DIFF
--- a/crates/spin-js-cli/build.rs
+++ b/crates/spin-js-cli/build.rs
@@ -14,7 +14,7 @@ fn stub_engine_for_clippy() {
     let engine_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("engine.wasm");
 
     if !engine_path.exists() {
-        std::fs::write(engine_path, &[]).expect("failed to write empty engine.wasm stub");
+        std::fs::write(engine_path, []).expect("failed to write empty engine.wasm stub");
         println!("cargo:warning=using stubbed engine.wasm for static analysis purposes...");
     }
 }

--- a/crates/spin-js-engine/src/js_sdk/modules/fsPromises.ts
+++ b/crates/spin-js-engine/src/js_sdk/modules/fsPromises.ts
@@ -1,19 +1,47 @@
+interface ReadDirOptions {
+    withFileTypes: boolean
+}
+
+interface ReadDirWithFileTypes {
+    name: string
+    isFile: () => boolean
+    isDirectory: () => boolean
+    isSymboliclink: () => boolean
+}
+
 declare const _fsPromises: {
     readFile: (arg0: string) => ArrayBuffer
+    readDir: {
+        (arg0: string): Array<string>
+        (arg0: string, arg1: ReadDirOptions & object): Array<ReadDirWithFileTypes>
+    }
 }
 
 /** @internal */
 const fsPromises = {
-    readFile: (filename: string) =>  {
+    readFile: (filename: string) => {
         return Promise.resolve(_fsPromises.readFile(filename))
+    },
+    readdir: (dirname: string, options?: ReadDirOptions) => {
+        if (options && options.withFileTypes == true) {
+            let res = _fsPromises.readDir(dirname, options)
+            return Promise.resolve(res)
+        }
+        return Promise.resolve(_fsPromises.readDir(dirname))
     }
 }
 
+
 declare global {
     const fsPromises: {
-        readFile: (filename: string) => Promise<ArrayBuffer>
+        readFile: (filename: string) => Promise<ArrayBuffer>,
+        readdir: {
+            (dirname: string, options: {withFileTypes: true}): Promise<Array<ReadDirWithFileTypes>>;
+            (dirname: string, options?: ReadDirOptions): Promise<Array<string>>;
+            (dirname: string, options: {withFileTypes?: false | undefined}): Promise<Array<string>>;
+        }
     }
 }
 
 /** @internal */
-export {fsPromises}
+export { fsPromises }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "spin-js-sdk",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}

--- a/types/lib/modules/fsPromises.d.ts
+++ b/types/lib/modules/fsPromises.d.ts
@@ -1,6 +1,24 @@
+interface ReadDirOptions {
+    withFileTypes: boolean;
+}
+interface ReadDirWithFileTypes {
+    name: string;
+    isFile: () => boolean;
+    isDirectory: () => boolean;
+    isSymboliclink: () => boolean;
+}
 declare global {
     const fsPromises: {
         readFile: (filename: string) => Promise<ArrayBuffer>;
+        readdir: {
+            (dirname: string, options: {
+                withFileTypes: true;
+            }): Promise<Array<ReadDirWithFileTypes>>;
+            (dirname: string, options?: ReadDirOptions): Promise<Array<string>>;
+            (dirname: string, options: {
+                withFileTypes?: false | undefined;
+            }): Promise<Array<string>>;
+        };
     };
 }
 export {};


### PR DESCRIPTION
Implemented a minimal read directory based on `nodejs`. I also added the option to request for filetypes. It does not have all the properties provided by the node but supports the major ones. 

While implementing the read directory I was wondering if we should implement `glob` as well as that seems to be straightforward to implement and might be useful.

Signed-off-by: karthik Ganeshram <karthik.ganeshram@fermyon.com>