### PR TITLE
Replace default Math.random() implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,6 +1293,7 @@ dependencies = [
  "once_cell",
  "quickjs-wasm-rs",
  "quickjs-wasm-sys",
+ "rand",
  "serde",
  "serde_bytes",
  "serde_derive",

--- a/crates/spin-js-engine/Cargo.toml
+++ b/crates/spin-js-engine/Cargo.toml
@@ -16,6 +16,7 @@ quickjs-wasm-sys = { git = "https://github.com/dicej/javy" }
 once_cell = "1.4.0"
 spin-sdk = { git = "https://github.com/fermyon/spin" }
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "dde4694aaa6acf9370206527a798ac4ba6a8c5b8" }
+rand = "0.8.5"
 serde = "1.0.137"
 serde_bytes = "0.11"
 serde_derive = "1.0.137"

--- a/crates/spin-js-engine/src/js_sdk/modules/random.ts
+++ b/crates/spin-js-engine/src/js_sdk/modules/random.ts
@@ -1,0 +1,7 @@
+declare var _random: {
+    get_rand: () => number
+}
+
+Math.random = function () {
+    return _random.get_rand();
+}

--- a/crates/spin-js-engine/src/js_sdk/sdk.ts
+++ b/crates/spin-js-engine/src/js_sdk/sdk.ts
@@ -6,20 +6,22 @@ import { fetch } from "./modules/spinSdk"
 import { HttpRequest, HttpResponse, HandleRequest } from "./modules/spinSdk"
 
 /** @internal */
-import {fsPromises} from "./modules/fsPromises"
+import { fsPromises } from "./modules/fsPromises"
 import "./modules/fsPromises"
 
 /** @internal */
-import {glob} from "./modules/glob"
+import { glob } from "./modules/glob"
 import "./modules/glob"
 
 /** @internal */
-import {atob, btoa, Buffer} from "./modules/stringHandling"
+import { atob, btoa, Buffer } from "./modules/stringHandling"
 
 import { URL } from "./modules/url"
 
+import "./modules/random"
+
 /** @internal */
-export { atob, btoa, Buffer, fetch, fsPromises, glob}
+export { atob, btoa, Buffer, fetch, fsPromises, glob }
 
 // Stuff to be exported to the sdk types file
 export { HttpRequest, HttpResponse, HandleRequest, URL }

--- a/crates/spin-js-engine/src/lib.rs
+++ b/crates/spin-js-engine/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(warnings)]
 
 use anyhow::bail;
+use rand::{thread_rng, Rng};
 use std::path::PathBuf;
 use std::rc::Rc;
 
@@ -245,12 +246,16 @@ fn get_glob(context: &Context, _this: &Value, args: &[Value]) -> Result<Value> {
                 array.append_property(context.value_from_str(&path?.to_string_lossy())?)?;
             }
             Ok(array)
-        },
+        }
         _ => bail!(
             "expected a single file name argument to read_file, got {} arguments",
             args.len()
         ),
     }
+}
+
+fn math_rand(context: &Context, _this: &Value, _args: &[Value]) -> Result<Value> {
+    return context.value_from_f64(thread_rng().gen_range(0.0_f64..1.0));
 }
 
 fn do_init() -> Result<()> {
@@ -291,6 +296,10 @@ fn do_init() -> Result<()> {
     let _glob = context.object_value()?;
     _glob.set_property("get", context.wrap_callback(get_glob)?)?;
 
+    let _random = context.object_value()?;
+    _random.set_property("get_rand", context.wrap_callback(math_rand)?)?;
+
+    global.set_property("_random", _random)?;
     global.set_property("spinSdk", spin_sdk)?;
     global.set_property("_fsPromises", fs_promises)?;
     global.set_property("_glob", _glob)?;

--- a/types/lib/index.d.ts
+++ b/types/lib/index.d.ts
@@ -2,4 +2,5 @@ import { HttpRequest, HttpResponse, HandleRequest } from "./modules/spinSdk";
 import "./modules/fsPromises";
 import "./modules/glob";
 import { URL } from "./modules/url";
+import "./modules/random";
 export { HttpRequest, HttpResponse, HandleRequest, URL };

--- a/types/lib/modules/random.d.ts
+++ b/types/lib/modules/random.d.ts
@@ -1,0 +1,3 @@
+declare var _random: {
+    get_rand: () => number;
+};


### PR DESCRIPTION
This just replaces the default `Math.random()` with a rust implementation as the default implementation does not provide random numbers. Just a fixed number for each build.

PS: We might still need to consider adding some crypto stuff as some libraries use that to generate random number/alphanumerics.

Signed-off-by: karthik Ganeshram <karthik.ganeshram@fermyon.com>