### PR TITLE
fix math random to use proper implementation

### DIFF
--- a/crates/spin-js-engine/src/js_sdk/sdk.ts
+++ b/crates/spin-js-engine/src/js_sdk/sdk.ts
@@ -20,6 +20,9 @@ import { atob, btoa, Buffer } from "./modules/stringHandling"
 import {crypto} from "./modules/crypto"
 
 /** @internal */
+import "./modules/random"
+
+/** @internal */
 import { URL, URLSearchParams } from "./modules/url"
 import "./modules/url"
 


### PR DESCRIPTION
We were not importing our implementation to the SDK, therefore it was defaulting to the original implementation that does not provide random numbers but just a single constant number for every build.

Signed-off-by: karthik Ganeshram <karthik.ganeshram@fermyon.com>