### PR TITLE
remove types folder in templates

### DIFF
--- a/templates/http-ts/content/types/package.json
+++ b/templates/http-ts/content/types/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "spin-sdk-types",
-  "version": "1.0.0",
-  "description": "",
-  "types": "./lib/index.d.ts",
-  "author": "",
-  "license": "ISC"
-}


### PR DESCRIPTION
As we now have a published package, this is no longer necessary.

Signed-off-by: karthik Ganeshram <karthik.ganeshram@fermyon.com>