### PR TITLE
fix URLSearchParams.entries and add iterator

### DIFF
--- a/crates/spin-js-engine/src/js_sdk/modules/url.ts
+++ b/crates/spin-js-engine/src/js_sdk/modules/url.ts
@@ -81,7 +81,25 @@ class URLSearchParams {
         delete this.queryParams[key]
     }
     entries() {
-        return Object.entries(this.queryParams)
+        let arr: Array<[string, string]> = []
+        Object.entries(this.queryParams).map(o => {
+            if (Array.isArray(o[1])) {
+                o[1].map(k => {
+                    arr.push([o[0], k])
+                })
+            } else {
+                arr.push([o[0], o[1]])
+            }
+        })
+        let iterLength = arr.length
+        let iterIndex = 0
+        return {
+            next: function() {
+                return iterIndex < iterLength ?
+               {value: arr[iterIndex++], done: false} :
+               {done: true};
+            }
+        }
     }
     get(key: string) {
         let val = this.queryParams[key]
@@ -114,6 +132,9 @@ class URLSearchParams {
     }
     values() {
         return Object.keys(this.queryParams).map(k => this.queryParams[k])
+    }
+    [Symbol.iterator]() { 
+        return this.entries()
     }
 }
 

--- a/types/lib/modules/overrides.d.ts
+++ b/types/lib/modules/overrides.d.ts
@@ -28,7 +28,7 @@ declare global {
         constructor(queryParamsString: string);
         append(key: string, val: string | Array<string>): void
         delete(key: string): void
-        entries(): Array<[string, string | Array<string>]>
+        entries(): Iterable<[string, string]>
         get(key: string): string
         getAll(key: string): string[]
         has(key: string): boolean


### PR DESCRIPTION
This commit changes the `entries` method to be consistent with the browser implementation.

Signed-off-by: karthik Ganeshram <karthik.ganeshram@fermyon.com>