### PR TITLE
add router to the SDK

### DIFF
--- a/crates/spin-js-engine/src/js_sdk/modules/router.ts
+++ b/crates/spin-js-engine/src/js_sdk/modules/router.ts
@@ -1,0 +1,85 @@
+/** @internal */
+import { Router as _router } from 'itty-router'
+import { HttpRequest } from './spinSdk'
+
+declare type GenericTraps = {
+    [key: string]: any;
+};
+
+export declare type RequestLike = {
+    method: string;
+    url: string;
+} & GenericTraps;
+
+declare type IRequest = {
+    method: string;
+    url: string;
+    params: {
+        [key: string]: string;
+    };
+    query: {
+        [key: string]: string | string[] | undefined;
+    };
+    proxy?: any;
+} & GenericTraps;
+
+interface RouteHandler {
+    (request: IRequest, ...args: any): any;
+}
+
+declare type RouteEntry = [string, RegExp, RouteHandler[]];
+declare type Route = <T extends RouterType>(path: string, ...handlers: RouteHandler[]) => T;
+declare type RouterHints = {
+    all: Route;
+    delete: Route;
+    get: Route;
+    options: Route;
+    patch: Route;
+    post: Route;
+    put: Route;
+};
+declare type RouterType = {
+    __proto__: RouterType;
+    routes: RouteEntry[];
+    handle: (request: RequestLike, ...extra: any) => Promise<any>;
+} & RouterHints;
+
+interface routerType {
+    all(path: string, ...handlers: RouteHandler[]): RouterType 
+    delete(path: string, ...handlers: RouteHandler[]): RouterType 
+    get(path: string, ...handlers: RouteHandler[]): RouterType 
+    handle(request: RequestLike, ...extras: any): Promise<any>
+    handleRequest(request: HttpRequest, ...extras: any): Promise<any>
+    options(path: string, ...handlers: RouteHandler[]): RouterType 
+    patch(path: string, ...handlers: RouteHandler[]): RouterType 
+    post(path: string, ...handlers: RouteHandler[]): RouterType 
+    put(path: string, ...handlers: RouteHandler[]): RouterType 
+    routes: RouteEntry[]
+}
+
+/** @internal */
+function router(): routerType {
+    let _spinRouter = _router()
+
+    return {
+        all: function (path: string, ...handlers: RouteHandler[]): RouterType { return _spinRouter.all(path, ...handlers) },
+        delete: function (path: string, ...handlers: RouteHandler[]): RouterType { return _spinRouter.delete(path, ...handlers) },
+        get: function (path: string, ...handlers: RouteHandler[]): RouterType { return _spinRouter.get(path, ...handlers) },
+        handle:function (request: RequestLike, ...extra: any): Promise<any> { return _spinRouter.handle(request, ...extra) },
+        handleRequest: function (request: HttpRequest, ...a: any): Promise<any> {
+            return _spinRouter.handle({
+                method: request.method,
+                url: request.headers["spin-full-url"]
+            }, ...a)
+        },
+        options: function (path: string, ...handlers: RouteHandler[]): RouterType { return _spinRouter.options(path, ...handlers) },
+        patch: function (path: string, ...handlers: RouteHandler[]): RouterType { return _spinRouter.patch(path, ...handlers) },
+        post: function (path: string, ...handlers: RouteHandler[]): RouterType { return _spinRouter.post(path, ...handlers) },
+        put: function (path: string, ...handlers: RouteHandler[]): RouterType { return _spinRouter.put(path, ...handlers) },
+        routes: _spinRouter.routes
+    }
+}
+
+/** @internal */
+export { router }
+export { routerType }

--- a/crates/spin-js-engine/src/js_sdk/modules/utils.ts
+++ b/crates/spin-js-engine/src/js_sdk/modules/utils.ts
@@ -1,21 +1,23 @@
 /** @internal */
 const arrayBufToBuf = require('typedarray-to-buffer')
-
 /** @internal */
-function toBuffer(arg0: ArrayBuffer): Buffer {
-    return arrayBufToBuf(arg0)
-}
+import { router} from "./router"
+import { routerType} from "./router"
 
 /** @internal */
 const utils = {
     toBuffer(arg0: ArrayBuffer): Buffer {
         return arrayBufToBuf(arg0)
-    } 
+    },
+    Router: () => {
+        return router()
+    }
 }
 
 declare global {
     const utils: {
         toBuffer(argo: ArrayBuffer): Buffer
+        Router(): routerType
     }
 }
 

--- a/crates/spin-js-engine/src/js_sdk/package-lock.json
+++ b/crates/spin-js-engine/src/js_sdk/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "buffer": "^6.0.3",
         "fast-text-encoding": "^1.0.6",
+        "itty-router": "^3.0.11",
         "query-string": "^7.1.1",
         "typedarray-to-buffer": "^4.0.0",
         "url-parse": "^1.5.10"
@@ -879,6 +880,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/itty-router": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-3.0.11.tgz",
+      "integrity": "sha512-vWsoHBi2CmU15YzyUeHjRfjdySL2jqZQKA9jP1LXkBcLJAo0KQNVlQMvhtzG0mzABhVYifeBF97UkrrpuTCWYQ=="
     },
     "node_modules/jest-worker": {
       "version": "27.5.1",
@@ -2329,6 +2335,11 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true
+    },
+    "itty-router": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/itty-router/-/itty-router-3.0.11.tgz",
+      "integrity": "sha512-vWsoHBi2CmU15YzyUeHjRfjdySL2jqZQKA9jP1LXkBcLJAo0KQNVlQMvhtzG0mzABhVYifeBF97UkrrpuTCWYQ=="
     },
     "jest-worker": {
       "version": "27.5.1",

--- a/crates/spin-js-engine/src/js_sdk/package.json
+++ b/crates/spin-js-engine/src/js_sdk/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "buffer": "^6.0.3",
     "fast-text-encoding": "^1.0.6",
+    "itty-router": "^3.0.11",
     "query-string": "^7.1.1",
     "typedarray-to-buffer": "^4.0.0",
     "url-parse": "^1.5.10"

--- a/crates/spin-js-engine/src/js_sdk/sdk.ts
+++ b/crates/spin-js-engine/src/js_sdk/sdk.ts
@@ -17,7 +17,7 @@ import "./modules/glob"
 import { atob, btoa, Buffer } from "./modules/stringHandling"
 
 /** @internal */
-import {crypto} from "./modules/crypto"
+import { crypto } from "./modules/crypto"
 
 /** @internal */
 import "./modules/random"
@@ -27,11 +27,12 @@ import { URL, URLSearchParams } from "./modules/url"
 import "./modules/url"
 
 /** @internal */
-import {utils} from "./modules/utils"
+import { utils } from "./modules/utils"
 import "./modules/utils"
 
+
 /** @internal */
-export { atob, btoa, Buffer, fetch, fsPromises, glob, crypto, URL, URLSearchParams, utils}
+export { atob, btoa, Buffer, fetch, fsPromises, glob, crypto, URL, URLSearchParams, utils }
 
 // Stuff to be exported to the sdk types file
-export { HttpRequest, HttpResponse, HandleRequest}
+export { HttpRequest, HttpResponse, HandleRequest }

--- a/types/lib/modules/router.d.ts
+++ b/types/lib/modules/router.d.ts
@@ -1,0 +1,51 @@
+import { HttpRequest } from './spinSdk';
+declare type GenericTraps = {
+    [key: string]: any;
+};
+export declare type RequestLike = {
+    method: string;
+    url: string;
+} & GenericTraps;
+declare type IRequest = {
+    method: string;
+    url: string;
+    params: {
+        [key: string]: string;
+    };
+    query: {
+        [key: string]: string | string[] | undefined;
+    };
+    proxy?: any;
+} & GenericTraps;
+interface RouteHandler {
+    (request: IRequest, ...args: any): any;
+}
+declare type RouteEntry = [string, RegExp, RouteHandler[]];
+declare type Route = <T extends RouterType>(path: string, ...handlers: RouteHandler[]) => T;
+declare type RouterHints = {
+    all: Route;
+    delete: Route;
+    get: Route;
+    options: Route;
+    patch: Route;
+    post: Route;
+    put: Route;
+};
+declare type RouterType = {
+    __proto__: RouterType;
+    routes: RouteEntry[];
+    handle: (request: RequestLike, ...extra: any) => Promise<any>;
+} & RouterHints;
+interface routerType {
+    all(path: string, ...handlers: RouteHandler[]): RouterType;
+    delete(path: string, ...handlers: RouteHandler[]): RouterType;
+    get(path: string, ...handlers: RouteHandler[]): RouterType;
+    handle(request: RequestLike, ...extras: any): Promise<any>;
+    handleRequest(request: HttpRequest, ...extras: any): Promise<any>;
+    options(path: string, ...handlers: RouteHandler[]): RouterType;
+    patch(path: string, ...handlers: RouteHandler[]): RouterType;
+    post(path: string, ...handlers: RouteHandler[]): RouterType;
+    put(path: string, ...handlers: RouteHandler[]): RouterType;
+    routes: RouteEntry[];
+}
+export { routerType };

--- a/types/lib/modules/utils.d.ts
+++ b/types/lib/modules/utils.d.ts
@@ -1,7 +1,8 @@
 /// <reference types="node" />
+import { routerType } from "./router";
 declare global {
     const utils: {
         toBuffer(argo: ArrayBuffer): Buffer;
+        Router(): routerType;
     };
 }
-export {};


### PR DESCRIPTION
Adds a router to the SDK using the `itty-router`

Usage example of the router 

```js
import { HandleRequest, HttpRequest, HttpResponse } from "spin-sdk"

const encoder = new TextEncoder()

router.get("/", () => {return {status: 200, body: encoder.encode("default route").buffer}})
router.get("/test", () => {return {status: 200, body: encoder.encode("test route").buffer}})

export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
    
    return await router.handle(request)
}
```

Signed-off-by: karthik Ganeshram <karthik.ganeshram@fermyon.com>