### PR TITLE
add createHmac method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,6 +500,7 @@ checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.3",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -709,6 +710,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1377,6 +1387,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "glob",
+ "hmac",
  "http",
  "once_cell",
  "quickjs-wasm-rs",
@@ -1457,6 +1468,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"

--- a/crates/spin-js-engine/Cargo.toml
+++ b/crates/spin-js-engine/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = [ "cdylib" ]
 anyhow = "1"
 bytes = { version = "1.2.1", features = ["serde"] }
 glob = "0.3.0"
+hmac = "0.12.1"
 http = "0.2"
 quickjs-wasm-rs = { git = "https://github.com/shopify/javy" }
 quickjs-wasm-sys = { git = "https://github.com/shopify/javy" }

--- a/crates/spin-js-engine/src/js_sdk/modules/crypto.ts
+++ b/crates/spin-js-engine/src/js_sdk/modules/crypto.ts
@@ -7,6 +7,7 @@ declare var _random: {
     math_rand: () => number
     get_rand: () => number
     get_hash: (algorithm: string, content: ArrayBuffer) => ArrayBuffer
+    get_hmac: (algorithm: string, key: ArrayBuffer, content: ArrayBuffer) => ArrayBuffer
 }
 
 /** @internal */
@@ -37,14 +38,16 @@ export const crypto = {
     createHash: function (algorithm: string) {
         let data = new Uint8Array()
         return {
-            update(content: string | Uint8Array, inputEncoding: string = "string") {
-                if (inputEncoding == "string") {
-                    // @ts-ignore
-                    content = encoder.encode(content)
+            update(content: string | Uint8Array, inputEncoding: string = "utf8") {
+                if (typeof (content) == "string") {
+                    if (inputEncoding == "utf8") {
+                        content = encoder.encode(content)
+                    } else {
+                        throw new Error("Currently only utf8 strings are supported")
+                    }
                 }
-                let  mergedArray = new Uint8Array(data.length + content.length);
+                let mergedArray = new Uint8Array(data.length + content.length);
                 mergedArray.set(data);
-                // @ts-ignore
                 mergedArray.set(content, data.length);
                 data = mergedArray
             },
@@ -57,6 +60,31 @@ export const crypto = {
                     throw new Error("sha256 and sha512 are the only supported algorithms");
             }
         }
+    },
+    createHmac: function (algorithm: string, key: ArrayBuffer) {
+        let data = new Uint8Array()
+        return {
+            update(content: string | Uint8Array, inputEncoding: string = "utf8") {
+                if (typeof (content) == "string") {
+                    if (inputEncoding == "utf8") {
+                        content = encoder.encode(content)
+                    } else {
+                        throw new Error("Currently only utf8 strings are supported")
+                    }
+                }
+                let mergedArray = new Uint8Array(data.length + content.length);
+                mergedArray.set(data);
+                mergedArray.set(content, data.length);
+                data = mergedArray
+            },
+            digest() {
+                if (algorithm == "sha256") {
+                    return _random.get_hmac("sha256", key, data.buffer)
+                } else if (algorithm == "sha512") {
+                    return _random.get_hmac("sha512", key, data.buffer)
+                } else
+                    throw new Error("sha256 and sha512 are the only supported algorithms");
+            }
+        }
     }
-
 }

--- a/types/lib/modules/overrides.d.ts
+++ b/types/lib/modules/overrides.d.ts
@@ -37,7 +37,7 @@ declare global {
         toString(): string
         values(): string[]
     }
-    interface Hash {
+    interface HashAndHmac {
         update(content: string | Uint8Array, inputEncoding?: string): void
         digest(): ArrayBuffer
     }
@@ -46,7 +46,8 @@ declare global {
         subtle: {
             digest(algorithm: string, content: ArrayBuffer): Promise<ArrayBuffer>
         }
-        createHash(algorithm: string): Hash
+        createHash(algorithm: string): HashAndHmac
+        createHmac(algorithm: string, key: ArrayBuffer): HashAndHmac
     }
 }
 


### PR DESCRIPTION
Implemented in a similar manner to `createHash` for the time being. Also fixes a small bug caused due to my misinterpretation of the docs with the `inputEncoding` argument. 

closes #100 

Signed-off-by: karthik Ganeshram <karthik.ganeshram@fermyon.com>