### PR TITLE
enable `Wizer::wasm_bulk_memory`

### DIFF
--- a/crates/spin-js-cli/Cargo.toml
+++ b/crates/spin-js-cli/Cargo.toml
@@ -8,7 +8,7 @@ name = "spinjs"
 path = "src/main.rs"
 
 [dependencies]
-wizer = "1.4.0"
+wizer = "1.6.0"
 structopt = "0.3"
 anyhow = "1.0"
 tempfile = "3.2.0"

--- a/crates/spin-js-cli/src/main.rs
+++ b/crates/spin-js-cli/src/main.rs
@@ -15,7 +15,10 @@ use {
 };
 
 #[derive(Debug, StructOpt)]
-#[structopt(name = "js2wasm", about = "A spin plugin to convert javascript files to Spin compatible modules")]
+#[structopt(
+    name = "js2wasm",
+    about = "A spin plugin to convert javascript files to Spin compatible modules"
+)]
 pub struct Options {
     #[structopt(parse(from_os_str))]
     pub input: PathBuf,
@@ -29,7 +32,7 @@ fn main() -> Result<()> {
 
     if env::var("SPIN_JS_WIZEN").eq(&Ok("1".into())) {
         env::remove_var("SPIN_JS_WIZEN");
-        
+
         println!("\nStarting to build Spin compatible module");
 
         let wasm: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/engine.wasm"));
@@ -40,6 +43,7 @@ fn main() -> Result<()> {
             let wasm = Wizer::new()
                 .allow_wasi(true)?
                 .inherit_stdio(true)
+                .wasm_bulk_memory(true)
                 .run(wasm)?;
             fs::write(&opts.output, wasm)?;
         }
@@ -50,6 +54,7 @@ fn main() -> Result<()> {
             let mut wasm = Wizer::new()
                 .allow_wasi(true)?
                 .inherit_stdio(true)
+                .wasm_bulk_memory(true)
                 .run(wasm)?;
 
             let codegen_cfg = CodegenConfig {

--- a/test/test-app/package-lock.json
+++ b/test/test-app/package-lock.json
@@ -25,6 +25,12 @@
       "extraneous": true,
       "license": "Apache-2.0"
     },
+    "../../types": {
+      "name": "@fermyon/spin-sdk",
+      "version": "0.2.0",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -1199,11 +1205,8 @@
       }
     },
     "node_modules/spin-sdk": {
-      "name": "@fermyon/spin-sdk",
-      "version": "0.2.0",
-      "resolved": "file:../../types",
-      "dev": true,
-      "license": "Apache-2.0"
+      "resolved": "../../types",
+      "link": true
     },
     "node_modules/supports-color": {
       "version": "8.1.1",
@@ -2454,8 +2457,7 @@
       }
     },
     "spin-sdk": {
-      "version": "npm:@fermyon/spin-sdk@0.2.0",
-      "dev": true
+      "version": "file:../../types"
     },
     "supports-color": {
       "version": "8.1.1",


### PR DESCRIPTION
As of Rust 1.67, the `wasm32-wasi` target seems to be using bulk memory operations by default, which means we need Wizer to support them, too.

Signed-off-by: Joel Dice <joel.dice@fermyon.com>