### PR TITLE
make return type flexible

### DIFF
--- a/crates/spin-js-engine/src/js_sdk/sdk.ts
+++ b/crates/spin-js-engine/src/js_sdk/sdk.ts
@@ -2,7 +2,7 @@
 require('fast-text-encoding')
 
 /** @internal */
-import { fetch } from "./modules/spinSdk"
+import { fetch, spinInternal } from "./modules/spinSdk"
 import { HttpRequest, HttpResponse, HandleRequest } from "./modules/spinSdk"
 
 /** @internal */
@@ -32,7 +32,7 @@ import "./modules/utils"
 
 
 /** @internal */
-export { atob, btoa, Buffer, fetch, fsPromises, glob, crypto, URL, URLSearchParams, utils }
+export { atob, btoa, Buffer, fetch, fsPromises, glob, crypto, URL, URLSearchParams, utils, spinInternal }
 
 // Stuff to be exported to the sdk types file
 export { HttpRequest, HttpResponse, HandleRequest }

--- a/crates/spin-js-engine/src/lib.rs
+++ b/crates/spin-js-engine/src/lib.rs
@@ -507,10 +507,20 @@ fn do_init() -> Result<()> {
 
     let global = context.global_object()?;
 
-    let entrypoint = global.get_property("spin")?.get_property("handleRequest")?;
-
-    if !entrypoint.is_function() {
-        panic!("expected function named \"handleRequest\" in \"spin\"");
+    let entrypoint;
+    match global
+        .get_property("spin")?
+        .get_property("handleRequest")?
+        .is_function()
+    {
+        // handler(req, res) signature exists
+        true => {
+            println!("choopsing new sig");
+            entrypoint = global
+                .get_property("spinInternal")?
+                .get_property("_handleRequest")?;
+        },
+        _ =>  panic!("expected function named \"handleRequest\" in \"spin\"")
     }
 
     let console = context.object_value()?;

--- a/test/test-app/package-lock.json
+++ b/test/test-app/package-lock.json
@@ -21,13 +21,7 @@
     },
     "../../types": {
       "name": "@fermyon/spin-sdk",
-      "version": "0.2.0",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "../../types": {
-      "name": "@fermyon/spin-sdk",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dev": true,
       "license": "Apache-2.0"
     },


### PR DESCRIPTION
This PR allows the return type to be more flexible on the body parameter

```js
export async function handleRequest(request) {

    return {
        status: 200,
        headers: { "foo": "bar" },
        body: "Hello from JS-SDK"
    }
}
```

This PR also adds a new handler function signature `handler(req, res)` which allows creating responses using chaining

```js
import { EventHandler, HttpRequest, HttpResponse } from "spin-sdk"

export const eventHandler: EventHandler = async function (request: HttpRequest, response: ResponseObject): Promise<void> {

    response.status(200).header("content-type", "text/html").body("Chaining works")
}
```


Signed-off-by: karthik Ganeshram <karthik.ganeshram@fermyon.com>