### PR TITLE
add new handler signature `handler(req, res)`

### DIFF
--- a/crates/spin-js-engine/src/js_sdk/modules/spinSdk.ts
+++ b/crates/spin-js-engine/src/js_sdk/modules/spinSdk.ts
@@ -141,7 +141,7 @@ class ResponseBuilder {
 declare global {
     const spin: {
         handleRequest(request: HttpRequest): Promise<HttpResponse>
-        eventHandler(request: HttpRequest, response: ResponseBuilder): Promise<HttpResponse>
+        handler(request: HttpRequest, response: ResponseBuilder): Promise<HttpResponse>
     }
 }
 
@@ -158,10 +158,10 @@ const spinInternal = {
             body: encodedBodyData || new Uint8Array().buffer
         }
     },
-    _eventHandler: async function (request: HttpRequest): Promise<HttpResponse> {
+    _handler: async function (request: HttpRequest): Promise<HttpResponse> {
 
         let response = new ResponseBuilder()
-        await spin.eventHandler(request, response)
+        await spin.handler(request, response)
 
         return {
             status: response.response.status,
@@ -171,7 +171,7 @@ const spinInternal = {
     }
 }
 
-type EventHandler = (request: HttpRequest, response: ResponseBuilder) => Promise<void>
+type Handler = (request: HttpRequest, response: ResponseBuilder) => Promise<void>
 
 
 declare global {
@@ -182,4 +182,4 @@ declare global {
 /** @internal */
 export { fetch, spinInternal }
 
-export { EventHandler, HttpRequest, HttpResponse, HandleRequest }
+export { Handler, HttpRequest, HttpResponse, HandleRequest }

--- a/crates/spin-js-engine/src/js_sdk/sdk.ts
+++ b/crates/spin-js-engine/src/js_sdk/sdk.ts
@@ -3,7 +3,7 @@ require('fast-text-encoding')
 
 /** @internal */
 import { fetch, spinInternal } from "./modules/spinSdk"
-import { HttpRequest, HttpResponse, HandleRequest } from "./modules/spinSdk"
+import { EventHandler, HttpRequest, HttpResponse, HandleRequest } from "./modules/spinSdk"
 
 /** @internal */
 import { fsPromises } from "./modules/fsPromises"
@@ -35,4 +35,4 @@ import "./modules/utils"
 export { atob, btoa, Buffer, fetch, fsPromises, glob, crypto, URL, URLSearchParams, utils, spinInternal }
 
 // Stuff to be exported to the sdk types file
-export { HttpRequest, HttpResponse, HandleRequest }
+export { EventHandler, HttpRequest, HttpResponse, HandleRequest }

--- a/crates/spin-js-engine/src/js_sdk/sdk.ts
+++ b/crates/spin-js-engine/src/js_sdk/sdk.ts
@@ -3,7 +3,7 @@ require('fast-text-encoding')
 
 /** @internal */
 import { fetch, spinInternal } from "./modules/spinSdk"
-import { EventHandler, HttpRequest, HttpResponse, HandleRequest } from "./modules/spinSdk"
+import { Handler, HttpRequest, HttpResponse, HandleRequest } from "./modules/spinSdk"
 
 /** @internal */
 import { fsPromises } from "./modules/fsPromises"
@@ -35,4 +35,4 @@ import "./modules/utils"
 export { atob, btoa, Buffer, fetch, fsPromises, glob, crypto, URL, URLSearchParams, utils, spinInternal }
 
 // Stuff to be exported to the sdk types file
-export { EventHandler, HttpRequest, HttpResponse, HandleRequest }
+export { Handler, HttpRequest, HttpResponse, HandleRequest }

--- a/crates/spin-js-engine/src/lib.rs
+++ b/crates/spin-js-engine/src/lib.rs
@@ -510,13 +510,13 @@ fn do_init() -> Result<()> {
     let entrypoint;
     if global
         .get_property("spin")?
-        .get_property("eventHandler")?
+        .get_property("handler")?
         .is_function()
     {
         // handler(req, res) signature exists
         entrypoint = global
             .get_property("spinInternal")?
-            .get_property("_eventHandler")?;
+            .get_property("_handler")?;
     } else if global
         .get_property("spin")?
         .get_property("handleRequest")?
@@ -527,7 +527,7 @@ fn do_init() -> Result<()> {
             .get_property("spinInternal")?
             .get_property("_handleRequest")?;
     } else {
-        panic!("expected function named \"handleRequest\" or \"eventHandler\"  in \"spin\"")
+        panic!("expected function named \"handleRequest\" or \"handler\"  in \"spin\"")
     }
 
     let console = context.object_value()?;

--- a/types/lib/index.d.ts
+++ b/types/lib/index.d.ts
@@ -1,7 +1,7 @@
-import { HttpRequest, HttpResponse, HandleRequest } from "./modules/spinSdk";
+import { EventHandler, HttpRequest, HttpResponse, HandleRequest } from "./modules/spinSdk";
 import "./modules/fsPromises";
 import "./modules/glob";
 import "./modules/url";
 import "./modules/utils";
-export { HttpRequest, HttpResponse, HandleRequest };
+export { EventHandler, HttpRequest, HttpResponse, HandleRequest };
 import "./modules/overrides"

--- a/types/lib/index.d.ts
+++ b/types/lib/index.d.ts
@@ -1,7 +1,7 @@
-import { EventHandler, HttpRequest, HttpResponse, HandleRequest } from "./modules/spinSdk";
+import { Handler, HttpRequest, HttpResponse, HandleRequest } from "./modules/spinSdk";
 import "./modules/fsPromises";
 import "./modules/glob";
 import "./modules/url";
 import "./modules/utils";
-export { EventHandler, HttpRequest, HttpResponse, HandleRequest };
+export { Handler, HttpRequest, HttpResponse, HandleRequest };
 import "./modules/overrides"

--- a/types/lib/modules/overrides.d.ts
+++ b/types/lib/modules/overrides.d.ts
@@ -49,6 +49,15 @@ declare global {
         createHash(algorithm: string): HashAndHmac
         createHmac(algorithm: string, key: ArrayBuffer): HashAndHmac
     }
+    class ResponseBuilder {
+        constructor()
+        getHeader(key: string): string | null
+        header(key: string, value: string): ThisType
+        status(status: number): ThisType
+        statusCode: number
+        body(data: ArrayBuffer | Uint8Array | string): ThisType
+     }
+     
 }
 
 export { }

--- a/types/lib/modules/spinSdk.d.ts
+++ b/types/lib/modules/spinSdk.d.ts
@@ -58,9 +58,9 @@ declare class ResponseBuilder {
     status(status: number): this;
     body(data: ArrayBuffer | Uint8Array | string): this;
 }
-declare type EventHandler = (request: HttpRequest, response: ResponseBuilder) => Promise<void>;
+declare type Handler = (request: HttpRequest, response: ResponseBuilder) => Promise<void>;
 declare global {
     const spinSdk: SpinSDK;
     function fetch(uri: string, options?: FetchOptions): Promise<FetchResult>;
 }
-export { EventHandler, HttpRequest, HttpResponse, HandleRequest };
+export { Handler, HttpRequest, HttpResponse, HandleRequest };

--- a/types/lib/modules/spinSdk.d.ts
+++ b/types/lib/modules/spinSdk.d.ts
@@ -49,8 +49,18 @@ interface FetchResult {
     text: () => Promise<string>;
     json: () => Promise<object>;
 }
+declare class ResponseBuilder {
+    response: HttpResponse;
+    statusCode: number;
+    constructor();
+    getHeader(key: string): string | null;
+    header(key: string, value: string): this;
+    status(status: number): this;
+    body(data: ArrayBuffer | Uint8Array | string): this;
+}
+declare type EventHandler = (request: HttpRequest, response: ResponseBuilder) => Promise<void>;
 declare global {
     const spinSdk: SpinSDK;
     function fetch(uri: string, options?: FetchOptions): Promise<FetchResult>;
 }
-export { HttpRequest, HttpResponse, HandleRequest };
+export { EventHandler, HttpRequest, HttpResponse, HandleRequest };


### PR DESCRIPTION
This PR introduces the following additional signature for the handler.

```js
import { EventHandler, HttpRequest, HttpResponse } from "spin-sdk"

export const eventHandler: EventHandler = async function (request: HttpRequest, response: ResponseObject): Promise<void> {

    response.status(200).header("content-type", "text/html").body("Chaining works")
}
```

Question: Is the function name `eventHandler` satisfactory or are there any other suggestions?

Signed-off-by: karthik Ganeshram <karthik.ganeshram@fermyon.com>