### PR TITLE
return null on nosuchkey

### DIFF
--- a/crates/spin-js-engine/src/js_sdk/modules/spinSdk.ts
+++ b/crates/spin-js-engine/src/js_sdk/modules/spinSdk.ts
@@ -39,7 +39,7 @@ type HandleRequest = (request: HttpRequest) => Promise<HttpResponse>
 interface KvStore {
     delete: (key: string) => void
     exists: (key: string) => boolean
-    get: (key: string) => ArrayBuffer
+    get: (key: string) => ArrayBuffer | null
     getKeys: () => Array<string>
     set: (key: string, value: ArrayBuffer | string) => void
 }

--- a/types/lib/modules/spinSdk.d.ts
+++ b/types/lib/modules/spinSdk.d.ts
@@ -22,7 +22,7 @@ declare type HandleRequest = (request: HttpRequest) => Promise<HttpResponse>;
 interface KvStore {
     delete: (key: string) => void;
     exists: (key: string) => boolean;
-    get: (key: string) => ArrayBuffer;
+    get: (key: string) => ArrayBuffer | null;
     getKeys: () => Array<string>;
     set: (key: string, value: ArrayBuffer | string) => void;
 }


### PR DESCRIPTION
Return `null` instead of an error when the key does not exist while using the `get` method on a KV store.