### PR TITLE
wrap `Store` in `Rc` prior to cloning

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
           toolchain: stable
           default: true
           components: clippy, rustfmt
-      
+
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "${{ runner.os }}-lint-${{ hashFiles('./Cargo.lock') }}"
@@ -57,13 +57,20 @@ jobs:
       - name: Install NPM dependancies for SDK
         shell: bash
         run: |
-          cd crates/spin-js-engine/src/js_sdk         
-          npm install -
+          cd crates/spin-js-engine/src/js_sdk
+          npm install
+
+      - name: Lint
+        shell: bash
+        run: |
+          cargo fmt --all -- --check
+          make crates/spin-js-engine/sdk.ts
+          QUICKJS_WASM_SYS_WASI_SDK_PATH=/opt/wasi-sdk cargo clippy --all-targets --all-features
 
       - name: Build spinjs
         shell: bash
         run: make
-      
+
       - name: Install spin
         uses: engineerd/configurator@v0.0.8
         with:
@@ -76,6 +83,3 @@ jobs:
         run: |
           cd test
           ./test.sh
-
-
- 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,9 +281,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clang-sys"
-version = "1.4.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3"
+checksum = "77ed9a53e5d4d9c573ae844bfac6872b159cb1d1585a83b29e7a64b7eef7332a"
 dependencies = [
  "glob",
  "libc",
@@ -570,7 +570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
  "humantime",
- "is-terminal 0.4.3",
+ "is-terminal 0.4.4",
  "log",
  "regex",
  "termcolor",
@@ -742,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -833,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes 1.0.5",
@@ -1138,7 +1138,7 @@ dependencies = [
 [[package]]
 name = "quickjs-wasm-rs"
 version = "0.1.4"
-source = "git+https://github.com/shopify/javy#47eeda542ba56d39a36cd0550759eedfc8eb0f3e"
+source = "git+https://github.com/shopify/javy#15d935e5809e6e1f91e2bbda7c67268e1ec9fc05"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -1149,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "quickjs-wasm-sys"
 version = "0.1.2"
-source = "git+https://github.com/shopify/javy#47eeda542ba56d39a36cd0550759eedfc8eb0f3e"
+source = "git+https://github.com/shopify/javy#15d935e5809e6e1f91e2bbda7c67268e1ec9fc05"
 dependencies = [
  "bindgen",
  "cc",
@@ -1478,7 +1478,7 @@ dependencies = [
 [[package]]
 name = "spin-macro"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/spin#e5c9b435a183e722ed6a0e8425c5285076620e65"
+source = "git+https://github.com/fermyon/spin#4831c2fe1546d6a081e3a0314dc882d5eaeba6b9"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1493,8 +1493,8 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.8.0"
-source = "git+https://github.com/fermyon/spin#e5c9b435a183e722ed6a0e8425c5285076620e65"
+version = "0.9.0"
+source = "git+https://github.com/fermyon/spin#4831c2fe1546d6a081e3a0314dc882d5eaeba6b9"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1549,9 +1549,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1818,9 +1818,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704553b4d614a47080b4a457a976b3c16174b19ce95b931b847561b590dd09ba"
+checksum = "68f7d56227d910901ce12dfd19acc40c12687994dfb3f57c90690f80be946ec5"
 dependencies = [
  "leb128",
 ]
@@ -2045,23 +2045,23 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "54.0.0"
+version = "54.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d3df4a63b10958fe98ab9d7e9a57a7bc900209d2b4edd10535bfb0703e6516"
+checksum = "3d48d9d731d835f4f8dacbb8de7d47be068812cb9877f5c60d408858778d8d2a"
 dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.24.0",
+ "wasm-encoder 0.24.1",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9a7c7d177696d0548178c36e377d49eba54170e885801d4270e2d44e82ac84"
+checksum = "d1db2e3ed05ea31243761439194bec3af6efbbaf87c4c8667fb879e4f23791a0"
 dependencies = [
- "wast 54.0.0",
+ "wast 54.0.1",
 ]
 
 [[package]]

--- a/crates/spin-js-cli/build.rs
+++ b/crates/spin-js-cli/build.rs
@@ -37,6 +37,6 @@ fn copy_engine_binary() {
     if engine_path.exists() {
         let copied_engine_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("engine.wasm");
 
-        fs::copy(&engine_path, &copied_engine_path).unwrap();
+        fs::copy(&engine_path, copied_engine_path).unwrap();
     }
 }

--- a/test/test-app/package-lock.json
+++ b/test/test-app/package-lock.json
@@ -19,12 +19,6 @@
         "webpack-cli": "^4.10.0"
       }
     },
-    "../../types": {
-      "name": "@fermyon/spin-sdk",
-      "version": "0.3.0",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
       "dev": true,
@@ -1084,8 +1078,11 @@
       }
     },
     "node_modules/spin-sdk": {
-      "resolved": "../../types",
-      "link": true
+      "name": "@fermyon/spin-sdk",
+      "version": "0.4.1",
+      "resolved": "file:../../types",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/supports-color": {
       "version": "8.1.1",
@@ -2081,7 +2078,8 @@
       }
     },
     "spin-sdk": {
-      "version": "file:../../types"
+      "version": "npm:@fermyon/spin-sdk@0.4.1",
+      "dev": true
     },
     "supports-color": {
       "version": "8.1.1",


### PR DESCRIPTION
Per https://github.com/fermyon/spin/pull/1200, `Store` should not have implemented `Clone` in the first place, so we wrap it in an `Rc` to avoid cloning it.

This also addresses some overdue Clippy fixes and adds Clippy and Rustfmt checks to CI.