### PR TITLE
add type for KvStore to global space

### DIFF
--- a/crates/spin-js-engine/src/js_sdk/modules/spinSdk.ts
+++ b/crates/spin-js-engine/src/js_sdk/modules/spinSdk.ts
@@ -36,14 +36,6 @@ interface HttpResponse extends BaseHttpResponse {
 
 type HandleRequest = (request: HttpRequest) => Promise<HttpResponse>
 
-interface KvStore {
-    delete: (key: string) => void
-    exists: (key: string) => boolean
-    get: (key: string) => ArrayBuffer | null
-    getKeys: () => Array<string>
-    set: (key: string, value: ArrayBuffer | string) => void
-}
-
 interface SpinSDK {
     config: SpinConfig
     /** @internal */
@@ -197,6 +189,13 @@ type Handler = (request: HttpRequest, response: ResponseBuilder) => Promise<void
 declare global {
     const spinSdk: SpinSDK
     function fetch(uri: string | URL, options?: FetchOptions): Promise<FetchResult>
+    interface KvStore {
+        delete: (key: string) => void
+        exists: (key: string) => boolean
+        get: (key: string) => ArrayBuffer | null
+        getKeys: () => Array<string>
+        set: (key: string, value: ArrayBuffer | string) => void
+    }
 }
 
 /** @internal */

--- a/types/lib/modules/spinSdk.d.ts
+++ b/types/lib/modules/spinSdk.d.ts
@@ -19,13 +19,6 @@ interface HttpResponse extends BaseHttpResponse {
     body?: ArrayBuffer | string | Uint8Array;
 }
 declare type HandleRequest = (request: HttpRequest) => Promise<HttpResponse>;
-interface KvStore {
-    delete: (key: string) => void;
-    exists: (key: string) => boolean;
-    get: (key: string) => ArrayBuffer | null;
-    getKeys: () => Array<string>;
-    set: (key: string, value: ArrayBuffer | string) => void;
-}
 interface SpinSDK {
     config: SpinConfig;
     redis: {
@@ -76,5 +69,12 @@ declare type Handler = (request: HttpRequest, response: ResponseBuilder) => Prom
 declare global {
     const spinSdk: SpinSDK;
     function fetch(uri: string | URL, options?: FetchOptions): Promise<FetchResult>;
+    interface KvStore {
+        delete: (key: string) => void;
+        exists: (key: string) => boolean;
+        get: (key: string) => ArrayBuffer | null;
+        getKeys: () => Array<string>;
+        set: (key: string, value: ArrayBuffer | string) => void;
+    }
 }
 export { Handler, HttpRequest, HttpResponse, HandleRequest };


### PR DESCRIPTION
fixes #141 

This does add `KvStore` to the global namespace. One other solution would be to add it as a property under `spinSdk` and use the following to declare the type.

```js
typeof spinSdk["KvStore"]
```