### PR TITLE
Pin versions of quickjs-wasm-sys and quickjs-wasm-rs

### DIFF
--- a/crates/spin-js-engine/Cargo.toml
+++ b/crates/spin-js-engine/Cargo.toml
@@ -12,8 +12,8 @@ bytes = { version = "1.2.1", features = ["serde"] }
 glob = "0.3.0"
 hmac = "0.12.1"
 http = "0.2"
-quickjs-wasm-rs = { git = "https://github.com/shopify/javy" }
-quickjs-wasm-sys = { git = "https://github.com/shopify/javy" }
+quickjs-wasm-rs = "0.1.4"
+quickjs-wasm-sys = "0.1.2"
 once_cell = "1.4.0"
 serde_json = "1.0.87"
 spin-sdk = { git = "https://github.com/fermyon/spin", default-features = false }


### PR DESCRIPTION
We have some upcoming breaking changes to the `quickjs-wasm-rs` crate, so it would be best to pin your dependency to a specific version

https://github.com/Shopify/javy/issues/295