### PR TITLE
Change template .wasm file to use project-name parameter

### DIFF
--- a/templates/http-js/content/package.json
+++ b/templates/http-js/content/package.json
@@ -4,7 +4,7 @@
   "description": "{{project-description}}",
   "main": "index.js",
   "scripts": {
-    "build": "npx webpack --mode=production && mkdir -p target && spin js2wasm -o target/spin-http-js.wasm dist/spin.js",
+    "build": "npx webpack --mode=production && mkdir -p target && spin js2wasm -o target/{{project-name | kebab_case}}.wasm dist/spin.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
@@ -14,6 +14,5 @@
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0"
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/templates/http-js/content/spin.toml
+++ b/templates/http-js/content/spin.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 
 [[component]]
 id = "{{project-name | kebab_case}}"
-source = "target/spin-http-js.wasm"
+source = "target/{{project-name | kebab_case}}.wasm"
 exclude_files = ["**/node_modules"]
 [component.trigger]
 route = "{{http-path}}"

--- a/templates/http-js/metadata/snippets/component.txt
+++ b/templates/http-js/metadata/snippets/component.txt
@@ -1,6 +1,6 @@
 [[component]]
 id = "{{project-name | kebab_case}}"
-source = "{{ output-path }}/target/spin-http-js.wasm"
+source = "{{ output-path }}/target/{{project-name | kebab_case}}.wasm"
 [component.trigger]
 route = "{{http-path}}"
 [component.build]

--- a/templates/http-ts/content/package.json
+++ b/templates/http-ts/content/package.json
@@ -4,7 +4,7 @@
   "description": "{{project-description}}",
   "main": "index.js",
   "scripts": {
-    "build": "npx webpack --mode=production && mkdir -p target && spin js2wasm -o target/spin-http-js.wasm dist/spin.js",
+    "build": "npx webpack --mode=production && mkdir -p target && spin js2wasm -o target/{{project-name | kebab_case}}.wasm dist/spin.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/templates/http-ts/content/spin.toml
+++ b/templates/http-ts/content/spin.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 
 [[component]]
 id = "{{project-name | kebab_case}}"
-source = "target/spin-http-js.wasm"
+source = "target/{{project-name | kebab_case}}.wasm"
 exclude_files = ["**/node_modules"]
 [component.trigger]
 route = "{{http-path}}"

--- a/templates/http-ts/metadata/snippets/component.txt
+++ b/templates/http-ts/metadata/snippets/component.txt
@@ -1,6 +1,6 @@
 [[component]]
 id = "{{project-name | kebab_case}}"
-source = "{{ output-path }}/target/spin-http-js.wasm"
+source = "{{ output-path }}/target/{{project-name | kebab_case}}.wasm"
 [component.trigger]
 route = "{{http-path}}"
 [component.build]


### PR DESCRIPTION
It makes sense to call the .wasm output file using the template name, as this is the convention we have for other templates.

A potential addition could be to parameterize this to use `{{project-name | kebab_case}}.wasm`, like the component id.

Marking this a draft until we agree on whether this should be parameterized.