### PR TITLE
add version back to cli options

### DIFF
--- a/crates/spin-js-cli/Cargo.toml
+++ b/crates/spin-js-cli/Cargo.toml
@@ -8,8 +8,8 @@ name = "spinjs"
 path = "src/main.rs"
 
 [dependencies]
-wizer = "3.0.0"
-clap = { version = "4.1.4", features = [ "derive" ] }
 anyhow = "1.0"
-tempfile = "3.2.0"
 binaryen = { git = "https://github.com/pepyakin/binaryen-rs" }
+clap = { version = "4.1.4", features = [ "derive" ] }
+tempfile = "3.2.0"
+wizer = "3.0.0"

--- a/crates/spin-js-cli/src/main.rs
+++ b/crates/spin-js-cli/src/main.rs
@@ -14,10 +14,13 @@ use {
     wizer::Wizer,
 };
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 #[derive(Debug, Parser)]
 #[clap(
     name = "js2wasm",
-    about = "A spin plugin to convert javascript files to Spin compatible modules"
+    about = "A spin plugin to convert javascript files to Spin compatible modules",
+    version = VERSION
 )]
 pub struct Options {
     pub input: PathBuf,


### PR DESCRIPTION
The switch from `structopt` to `clap` seems to have introduced a regression in the CLI arguments for version.