### PR TITLE
return null if key does not exist for Kv.getJson

### DIFF
--- a/spin-sdk/src/modules/spinSdk.ts
+++ b/spin-sdk/src/modules/spinSdk.ts
@@ -180,7 +180,12 @@ const kv = {
     open: (name: string) => {
         let store = __internal__.spin_sdk.kv.open(name)
         store.getJson = (key: string) => {
-            return JSON.parse(new TextDecoder().decode(store.get(key)))
+            let val = store.get(key)
+            if(val) {
+                return JSON.parse(new TextDecoder().decode(val))
+            } else {
+                return null
+            }
         }
         store.setJson = (key: string, value: any) => {
             store.set(key, JSON.stringify(value))


### PR DESCRIPTION
Return `null` instead of erroring out when the key does not exist to be in line with the behavior of `get`.