### PR TITLE
ci(release.yaml): bump ncipollo/release-action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
           tag_name: canary
 
       - name: Recreate canary tag and release
-        uses: ncipollo/release-action@v1.10.0
+        uses: ncipollo/release-action@v1.12.0
         with:
           tag: canary
           allowUpdates: true


### PR DESCRIPTION
- Bumps ncipollo/release-action to address deprecation warnings seen in CI (https://github.com/fermyon/spin-js-sdk/actions/runs/6176501111)

(The v1.12.0 version is working well for us in the cloud-plugin repo: https://github.com/fermyon/cloud-plugin/pull/64)