### PR TITLE
ci(.github): replace unmaintained actions-rs action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,11 +89,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install latest Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
-          target: ${{ matrix.config.target }}
+        shell: bash
+        run: |
+          rustup toolchain install stable
+          rustup default stable
+
+      - name: Install target
+        if: matrix.config.target != ''
+        shell: bash
+        run: rustup target add --toolchain stable ${{ matrix.config.target }}
 
       - name: set the release version (main)
         shell: bash

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,11 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install latest Rust stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
-          components: clippy, rustfmt
+        shell: bash
+        run: |
+          rustup toolchain install stable --component clippy --component rustfmt
+          rustup default stable
 
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
The actions-rs/toolchain GH action is no longer maintained and produces a lot of deprecation warnings, so replacing it here with shell commands (rustup cli tools are included by default in the GH Ubuntu runners)

This has been working well for us in the spin and cloud-plugin repos...