### PR TITLE
ci(release.yml): only recreate canary once all artifacts are ready to upload

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,32 +13,9 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  reset_canary_release: 
-    name: Delete and create Canary Release
-    runs-on: ubuntu-latest
-    steps:
-      
-      - name: Delete canary tag
-        uses: dev-drprasad/delete-tag-and-release@v0.2.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: canary
-
-      - name: Recreate canary tag and release
-        uses: ncipollo/release-action@v1.12.0
-        with:
-          tag: canary
-          allowUpdates: true
-          prerelease: true
-          body: |
-            This is a "canary" release of the most recent commits on our main branch. Canary is **not stable**.
-            It is only intended for developers wishing to try out the latest features in Spin-js-sdk, some of which may not be fully implemented.
-
   build:
     name: Build spinjs
     runs-on: ${{ matrix.config.os }}
-    needs: reset_canary_release
     strategy:
       fail-fast: false
       matrix:
@@ -189,7 +166,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v3
         with:
-            name: js2wasm-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
+            name: js2wasm
             path: _dist/js2wasm-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
             
       - name: upload binary to Github release
@@ -200,19 +177,11 @@ jobs:
           file: _dist/js2wasm-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
           tag: ${{ github.ref }}
 
-      - name: upload binary to Github release (canary)
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: _dist/js2wasm-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
-          tag: "canary"
-
   checksums_and_manifests:
     name: generate checksums
     runs-on: ubuntu-latest
     needs: build
     steps:
-
       - uses: actions/checkout@v3
       - name: set the release version (main)
         shell: bash
@@ -225,11 +194,18 @@ jobs:
 
       - name: download release assets
         uses: actions/download-artifact@v3
+        with:
+          name: js2wasm
 
       - name: generate checksums
         run: |
           ls -lh
-          sha256sum js2wasm*.tar.gz/js2wasm*.tar.gz > checksums-${{ env.RELEASE_VERSION }}.txt
+          sha256sum js2wasm*.tar.gz > checksums-${{ env.RELEASE_VERSION }}.txt
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: js2wasm
+          path: checksums-${{ env.RELEASE_VERSION }}.txt
 
       - name: upload checksums to Github release
         if: startsWith(github.ref, 'refs/tags/v')
@@ -239,27 +215,50 @@ jobs:
           file: checksums-${{ env.RELEASE_VERSION }}.txt
           tag: ${{ github.ref }}
 
-      - name: upload checksums to Github release (canary)
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: checksums-${{ env.RELEASE_VERSION }}.txt
-          tag: "canary"
-
       - name: create plugin manifest
         shell: bash
         run: bash .plugin-manifests/generate-manifest.sh ${{ env.RELEASE_VERSION }} checksums-${{ env.RELEASE_VERSION }}.txt > js2wasm.json
 
-      - name: upload plugin manifest to releases
+      - uses: actions/upload-artifact@v3
+        with:
+          name: js2wasm
+          path: js2wasm.json
+
+      - name: upload plugin manifest to release
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: js2wasm.json
-          tag: ${{ env.RELEASE_VERSION }}
+          tag: ${{ github.ref }}
 
-      
+  reset_canary_release: 
+    name: Delete and create Canary Release
+    runs-on: ubuntu-latest
+    needs: checksums_and_manifests
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: download release assets
+        uses: actions/download-artifact@v3
+        with:
+          name: js2wasm
 
-      
+      - name: Delete canary tag
+        uses: dev-drprasad/delete-tag-and-release@v0.2.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: canary
+          delete_release: true
 
- 
+      - name: Recreate canary tag and release
+        uses: ncipollo/release-action@v1.12.0
+        with:
+          tag: canary
+          allowUpdates: true
+          prerelease: true
+          artifacts: "js2wasm*.tar.gz,js2wasm.json,checksums-canary.txt"
+          commit: ${{ github.sha }}
+          body: |
+            This is a "canary" release of the most recent commits on our main branch. Canary is **not stable**.
+            It is only intended for developers wishing to try out the latest features in spin-js-sdk, some of which may not be fully implemented.


### PR DESCRIPTION
Similar to https://github.com/fermyon/cloud-plugin/pull/85

Run on my fork: https://github.com/vdice/spin-js-sdk/actions/runs/6190374793