### PR TITLE
version bump to v0.6.1

### DIFF
--- a/crates/spin-js-cli/Cargo.toml
+++ b/crates/spin-js-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-js-cli"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [[bin]]

--- a/crates/spin-js-engine/Cargo.toml
+++ b/crates/spin-js-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-js-engine"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
New patch release with builds based on ubuntu 20.04 to resolve `GLIBC` issues