### PR TITLE
Use `content-type` header in templates

### DIFF
--- a/templates/http-js/content/src/index.js
+++ b/templates/http-js/content/src/index.js
@@ -2,7 +2,7 @@ export async function handleRequest(request) {
 
     return {
         status: 200,
-        headers: { "foo": "bar" },
+        headers: { "content-type": "text/plain" },
         body: "Hello from JS-SDK"
     }
 }

--- a/templates/http-ts/content/src/index.ts
+++ b/templates/http-ts/content/src/index.ts
@@ -3,7 +3,7 @@ import { HandleRequest, HttpRequest, HttpResponse } from "@fermyon/spin-sdk"
 export const handleRequest: HandleRequest = async function (request: HttpRequest): Promise<HttpResponse> {
   return {
     status: 200,
-    headers: { "foo": "bar" },
+    headers: { "content-type": "text/plain" },
     body: "Hello from TS-SDK"
   }
 }


### PR DESCRIPTION
I have no idea how we ever settled on `"foo: bar"` as the appropriate header to use in _all our templates ever_ but IT STOPS HERE AND NOW, except when IT STOPS IN OTHER PLACES AT DIFFERENT TIMES.

Good.  I feel better now.
