### PR TITLE
docs(templates): add minimal build/run docs to template READMEs

### DIFF
--- a/templates/http-js/content/README.md
+++ b/templates/http-js/content/README.md
@@ -1,3 +1,20 @@
 ## HTTP-JS template
 
 This is a simple template to get started with spin-js-sdk.
+
+### Build
+
+```console
+npm install
+spin build
+```
+
+### Run
+
+```console
+spin up
+```
+
+Or, use `spin watch` to run the app and rebuild on any changes to `package.json` or the files in `src`.
+
+Use e.g. `curl -v http://127.0.0.1:3000/hello` to test the endpoint.

--- a/templates/http-ts/content/README.md
+++ b/templates/http-ts/content/README.md
@@ -1,3 +1,20 @@
 ## HTTP-TS template
 
 This is a simple template to get started with spin-js-sdk using typescript.
+
+### Build
+
+```console
+npm install
+spin build
+```
+
+### Run
+
+```console
+spin up
+```
+
+Or, use `spin watch` to run the app and rebuild on any changes to `package.json` or the files in `src`.
+
+Use e.g. `curl -v http://127.0.0.1:3000/hello` to test the endpoint.


### PR DESCRIPTION
Inspired by @calebschoepp's recent [PR adding watch config to the templates](https://github.com/fermyon/spin-js-sdk/pull/211).  Added a few example commands to the READMEs.