### PR TITLE
Add `allowed_outbound_hosts` to Templates

### DIFF
--- a/templates/http-js/content/spin.toml
+++ b/templates/http-js/content/spin.toml
@@ -13,6 +13,8 @@ component = "{{project-name | kebab_case}}"
 [component.{{project-name | kebab_case}}]
 source = "target/{{project-name | kebab_case}}.wasm"
 exclude_files = ["**/node_modules"]
+allowed_outbound_hosts = []
+
 [component.{{project-name | kebab_case}}.build]
 command = "npm run build"
 watch = ["src/**/*.js", "package.json"]

--- a/templates/http-js/metadata/snippets/component.txt
+++ b/templates/http-js/metadata/snippets/component.txt
@@ -4,6 +4,8 @@ component = "{{project-name | kebab_case}}"
 
 [component.{{project-name | kebab_case}}]
 source = "{{ output-path }}/target/{{project-name | kebab_case}}.wasm"
+allowed_outbound_hosts = []
+
 [component.{{project-name | kebab_case}}.build]
 command = "npm run build"
 workdir = "{{ output-path }}"

--- a/templates/http-ts/content/spin.toml
+++ b/templates/http-ts/content/spin.toml
@@ -13,6 +13,8 @@ component = "{{project-name | kebab_case}}"
 [component.{{project-name | kebab_case}}]
 source = "target/{{project-name | kebab_case}}.wasm"
 exclude_files = ["**/node_modules"]
+allowed_outbound_hosts = []
+
 [component.{{project-name | kebab_case}}.build]
 command = "npm run build"
 watch = ["src/**/*.ts", "package.json"]

--- a/templates/http-ts/metadata/snippets/component.txt
+++ b/templates/http-ts/metadata/snippets/component.txt
@@ -4,6 +4,8 @@ component = "{{project-name | kebab_case}}"
 
 [component.{{project-name | kebab_case}}]
 source = "{{ output-path }}/target/{{project-name | kebab_case}}.wasm"
+allowed_outbound_hosts = []
+
 [component.{{project-name | kebab_case}}.build]
 command = "npm run build"
 workdir = "{{ output-path }}"


### PR DESCRIPTION
I stumbled upon a small difference in the Spin Templates across different languages. 

With this PR, the `allowed_outbound_hosts` property is set on the component in `spin.toml` as it is done in templates for Rust and TinyGo.