### PR TITLE
catch exceptions in handler function and wait until handler completes

### DIFF
--- a/templates/http-ts/content/src/spin.ts
+++ b/templates/http-ts/content/src/spin.ts
@@ -19,13 +19,15 @@ async function handleEvent(event: FetchEvent) {
     let res = new ResponseBuilder(resolve);
 
     try {
-        // In case you want to do sonme work after the response is sent
+        // In case you want to do some work after the response is sent
         // uncomment the line below and comment out the line with 
-        // `await handler(event.request, res)
+        // await handler(event.request, res)
         // event.waitUntil(handler(event.request, res))
         await handler(event.request, res)
     } catch (e: any) {
-        res.status(500)
-        res.send(`error in handler: ${e}`)
+        if (res.getStatus() == 200) {
+            res.status(500);
+        }
+        res.send(`error in handler: ${e}`);
     }
 }

--- a/templates/http-ts/content/src/spin.ts
+++ b/templates/http-ts/content/src/spin.ts
@@ -18,5 +18,14 @@ async function handleEvent(event: FetchEvent) {
 
     let res = new ResponseBuilder(resolve);
 
-    await handler(event.request, res)
+    try {
+        // In case you want to do sonme work after the response is sent
+        // uncomment the line below and comment out the line with 
+        // `await handler(event.request, res)
+        // event.waitUntil(handler(event.request, res))
+        await handler(event.request, res)
+    } catch (e: any) {
+        res.status(500)
+        res.send(`error in handler: ${e}`)
+    }
 }


### PR DESCRIPTION
This PR adds a `try...catch` to the template so that any unhandled exceptions are caught and returned as an error instead of the generic error along the lines of `event loop error - both task and job queues are empty, but expected operations did not resolveInternal error.`

This PR also modifies the template so that there is an `event.waitUntill` on the handler function so that applications can do some work even after the response is sent. 