### PR TITLE
Fix knitwit generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "@fermyon/spin-sdk",
       "version": "2.0.0",
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@bytecodealliance/componentize-js": "^0.10.2",
@@ -174,7 +173,8 @@
     },
     "node_modules/@fermyon/knitwit": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/fermyon/knitwit.git#09a7d30e63ebbe333ec4b682b253ecda5a792768",
+      "resolved": "git+ssh://git@github.com/fermyon/knitwit.git#333f71d5d2db5181f2002c5fb9b98d0fb33e32e3",
+      "license": "ISC",
       "dependencies": {
         "@bytecodealliance/preview2-shim": "^0.16.4",
         "proper-lockfile": "^4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fermyon/spin-sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fermyon/spin-sdk",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@bytecodealliance/componentize-js": "^0.10.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "fmt-check": "prettier --check \"src/**/*.{ts,tsx,js,jsx}\"",
     "build": "tsc && cp -r src/types ./lib/",
     "build-docs": "typedoc  --plugin typedoc-plugin-missing-exports src/index.ts --out ./docs --excludeExternals --readme none",
-    "postinstall": "knitwit-postinstall",
+    "postprepare": "knitwit-postinstall",
     "fmt-examples": "prettier --write \"examples/**/*.{ts,tsx,js,jsx}\" --ignore-patterm \"node_modules\""
   },
   "sideEffects": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fermyon/spin-sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
Moves the `knitwit` script to `postprepare` instead of `postinsall` which seems to lead to errors when cloning a repository that already has a `package-lock.json` but the modules are not installed. 