### PR TITLE
bump version number to 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fermyon/spin-sdk",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fermyon/spin-sdk",
-      "version": "2.0.2",
+      "version": "2.1.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fermyon/spin-sdk",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
Version bump for a new minor release following the bump in the `ComponentizeJS` versions. This will allow us to add templates for the redis trigger as well.