### PR TITLE
bump templates to v2.3

### DIFF
--- a/templates/http-js/content/package.json
+++ b/templates/http-js/content/package.json
@@ -14,10 +14,9 @@
     "devDependencies": {
         "mkdirp": "^3.0.1",
         "webpack": "^5.74.0",
-        "webpack-cli": "^4.10.0",
-        "@fermyon/knitwit": "https://github.com/fermyon/knitwit#127f09d1f4c5992ee94243583940ef7e28df443e"
+        "webpack-cli": "^4.10.0"
     },
     "dependencies": {
-        "@fermyon/spin-sdk": "^2.2.0"
+        "@fermyon/spin-sdk": "^2.3.0"
     }
 }

--- a/templates/http-ts/content/package.json
+++ b/templates/http-ts/content/package.json
@@ -16,10 +16,9 @@
         "ts-loader": "^9.4.1",
         "typescript": "^4.8.4",
         "webpack": "^5.74.0",
-        "webpack-cli": "^4.10.0",
-        "@fermyon/knitwit": "https://github.com/fermyon/knitwit#127f09d1f4c5992ee94243583940ef7e28df443e"
+        "webpack-cli": "^4.10.0"
     },
     "dependencies": {
-        "@fermyon/spin-sdk": "^2.2.0"
+        "@fermyon/spin-sdk": "^2.3.0"
     }
 }

--- a/templates/redis-js/content/package.json
+++ b/templates/redis-js/content/package.json
@@ -14,10 +14,9 @@
     "devDependencies": {
         "mkdirp": "^3.0.1",
         "webpack": "^5.74.0",
-        "webpack-cli": "^4.10.0",
-        "@fermyon/knitwit": "https://github.com/fermyon/knitwit#127f09d1f4c5992ee94243583940ef7e28df443e"
+        "webpack-cli": "^4.10.0"
     },
     "dependencies": {
-        "@fermyon/spin-sdk": "^2.2.0"
+        "@fermyon/spin-sdk": "^2.3.0"
     }
 }

--- a/templates/redis-ts/content/package.json
+++ b/templates/redis-ts/content/package.json
@@ -16,10 +16,9 @@
         "ts-loader": "^9.4.1",
         "typescript": "^4.8.4",
         "webpack": "^5.74.0",
-        "webpack-cli": "^4.10.0",
-        "@fermyon/knitwit": "https://github.com/fermyon/knitwit#127f09d1f4c5992ee94243583940ef7e28df443e"
+        "webpack-cli": "^4.10.0"
     },
     "dependencies": {
-        "@fermyon/spin-sdk": "^2.2.0"
+        "@fermyon/spin-sdk": "^2.3.0"
     }
 }


### PR DESCRIPTION
`knitwit` can now be used transitively from the `@fermyon/spin-sdk` package. 