### PR TITLE
make spin2 default and bump patch version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fermyon/spin-sdk",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fermyon/spin-sdk",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fermyon/spin-sdk",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -13,7 +13,7 @@
     "fmt-check": "prettier --check \"src/**/*.{ts,tsx,js,jsx}\"",
     "build": "tsc && cp -r src/types ./lib/",
     "build-docs": "typedoc  --plugin typedoc-plugin-missing-exports src/index.ts --out ./docs --excludeExternals --readme none",
-    "postinstall": "knitwit-postinstall --wit-path ../../bin/wit --world spin3-imports",
+    "postinstall": "knitwit-postinstall --wit-path ../../bin/wit --world spin-imports",
     "fmt-examples": "prettier --write \"examples/**/*.{ts,tsx,js,jsx}\" --ignore-patterm \"node_modules\""
   },
   "sideEffects": false,

--- a/src/postgresv3.ts
+++ b/src/postgresv3.ts
@@ -1,3 +1,11 @@
+/**
+ * PostgresV3 enables interacting with a Postgres database using Spin's v3 interface.
+ * To use this module you  need to add `spin3-imports` to your `knitwit.json` file and run
+ * `npx knitwit`.
+ *
+ * @module PostgresV3
+ */
+
 //@ts-ignore
 import * as spinPg from 'spin:postgres/postgres@3.0.0';
 


### PR DESCRIPTION
Importing `spin3-imports` by default leads to `PostgresV3` imports making it into the binary because treeshaking is partially disabled. This fixes so that if users need to use Spin v3 imports they would have to opt in by specifying in the `knitwit.json`. 