### PR TITLE
bump componentizeJS and make build script dependant on the version of CJS as well

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,6 @@ jobs:
           uses: fermyon/actions/spin/setup@v1
           with:
             github_token: ${{ secrets.GITHUB_TOKEN }}
-            version: "v3.0.0-rc.1"
 
         - name: Run Test
           shell: bash

--- a/bin/j2w.mjs
+++ b/bin/j2w.mjs
@@ -8,6 +8,7 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import path from 'path';
 
+const componentizeVersion = '0.16.0';
 const __filename = new URL(import.meta.url).pathname;
 const __dirname = __filename.substring(0, __filename.lastIndexOf('/'));
 
@@ -39,15 +40,21 @@ const args = yargs(hideBin(process.argv))
 
 const src = args.input;
 const outputPath = args.output;
-const inputChecksumPath = `${src}.checksum`;
+const buildDataPath = `${src}.buildData.json`;
 
 // Function to calculate file checksum
 async function calculateChecksum(filePath) {
-    const fileBuffer = await readFile(filePath);
-    const hash = createHash('sha256');
-    hash.update(fileBuffer);
-    return hash.digest('hex');
+    try {
+        const fileBuffer = await readFile(filePath);
+        const hash = createHash('sha256');
+        hash.update(fileBuffer);
+        return hash.digest('hex');
+    } catch (error) {
+        console.error(`Error calculating checksum for file ${filePath}:`, error);
+        throw error;
+    }
 }
+
 
 // Function to check if a file exists
 async function fileExists(filePath) {
@@ -59,47 +66,67 @@ async function fileExists(filePath) {
     }
 }
 
-async function getExistingChecksum(checksumPath) {
-    if (await fileExists(checksumPath)) {
-        return await readFile(checksumPath, 'utf8');
+async function getExistingBuildData(buildaDataPath) {
+    try {
+        if (await fileExists(buildaDataPath)) {
+            const buildData = await readFile(checksumPath, 'utf8');
+            return JSON.parse(buildData);
+        }
+        return null;
+    } catch (error) {
+        console.error(`Error reading existing checksum file at ${checksumPath}:`, error);
+        throw error;
     }
-    return null;
 }
 
-async function saveChecksum(checksumPath, checksum) {
-    await writeFile(checksumPath, checksum);
+async function saveBuildData(checksumPath, checksum, version) {
+    try {
+        const checksumData = {
+            version,
+            checksum
+        };
+        await writeFile(checksumPath, JSON.stringify(checksumData, null, 2));
+    } catch (error) {
+        console.error(`Error saving checksum file at ${checksumPath}:`, error);
+        throw error;
+    }
 }
 
 (async () => {
-    const sourceChecksum = await calculateChecksum(src);
-    const existingChecksum = await getExistingChecksum(inputChecksumPath);
+    try {
+        const sourceChecksum = await calculateChecksum(src);
+        const existingBuildData = await getExistingBuildData(buildDataPath);
 
-    if ((existingChecksum === sourceChecksum) && fileExists(outputPath)) {
-        console.log("No changes detected in source file. Skipping componentization.");
-        return;
+        if (existingBuildData?.version == componentizeVersion && existingBuildData?.checksum === sourceChecksum && await fileExists(outputPath)) {
+            console.log("No changes detected in source file. Skipping componentization.");
+            return;
+        }
+
+        const source = await readFile(src, 'utf8');
+
+        // Check if a non-default wit directory is supplied
+        const witPath = args.witPath ? resolve(args.witPath) : path.join(__dirname, 'wit');
+        if (args.witPath) {
+            console.log(`Using user-provided wit in: ${witPath}`);
+        }
+
+        const { component } = await componentize(source, {
+            sourceName: basename(src),
+            witPath,
+            worldName: args.triggerType,
+            disableFeatures: [],
+            enableFeatures: ["http"],
+            enableAot: args.aot
+        });
+
+        await writeFile(outputPath, component);
+
+        // Save the checksum of the input file along with the componentize version
+        await saveBuildData(buildDataPath, sourceChecksum, componentizeVersion);
+
+        console.log("Component successfully written.");
+    } catch (error) {
+        console.error("An error occurred during the componentization process:", error);
+        process.exit(1);
     }
-
-    const source = await readFile(src, 'utf8');
-
-    // Check if a non-default wit directory is supplied
-    const witPath = args.witPath ? resolve(args.witPath) : path.join(__dirname, 'wit');
-    if (args.witPath) {
-        console.log(`Using user-provided wit in: ${witPath}`);
-    }
-
-    const { component } = await componentize(source, {
-        sourceName: basename(src),
-        witPath,
-        worldName: args.triggerType,
-        disableFeatures: [],
-        enableFeatures: ["http"],
-        enableAot: args.aot
-    });
-
-    await writeFile(outputPath, component);
-
-    // Save the checksum of the input file
-    await saveChecksum(inputChecksumPath, sourceChecksum);
-
-    console.log("Component successfully written.");
 })();

--- a/bin/wit/deps/cli/command.wit
+++ b/bin/wit/deps/cli/command.wit
@@ -1,7 +1,10 @@
-package wasi:cli@0.2.0;
+package wasi:cli@0.2.3;
 
+@since(version = 0.2.0)
 world command {
+  @since(version = 0.2.0)
   include imports;
 
+  @since(version = 0.2.0)
   export run;
 }

--- a/bin/wit/deps/cli/environment.wit
+++ b/bin/wit/deps/cli/environment.wit
@@ -1,3 +1,4 @@
+@since(version = 0.2.0)
 interface environment {
   /// Get the POSIX-style environment variables.
   ///
@@ -7,12 +8,15 @@ interface environment {
   /// Morally, these are a value import, but until value imports are available
   /// in the component model, this import function should return the same
   /// values each time it is called.
+  @since(version = 0.2.0)
   get-environment: func() -> list<tuple<string, string>>;
 
   /// Get the POSIX-style arguments to the program.
+  @since(version = 0.2.0)
   get-arguments: func() -> list<string>;
 
   /// Return a path that programs should use as their initial current working
   /// directory, interpreting `.` as shorthand for this.
+  @since(version = 0.2.0)
   initial-cwd: func() -> option<string>;
 }

--- a/bin/wit/deps/cli/exit.wit
+++ b/bin/wit/deps/cli/exit.wit
@@ -1,4 +1,17 @@
+@since(version = 0.2.0)
 interface exit {
   /// Exit the current instance and any linked instances.
+  @since(version = 0.2.0)
   exit: func(status: result);
+
+  /// Exit the current instance and any linked instances, reporting the
+  /// specified status code to the host.
+  ///
+  /// The meaning of the code depends on the context, with 0 usually meaning
+  /// "success", and other values indicating various types of failure.
+  ///
+  /// This function does not return; the effect is analogous to a trap, but
+  /// without the connotation that something bad has happened.
+  @unstable(feature = cli-exit-with-code)
+  exit-with-code: func(status-code: u8);
 }

--- a/bin/wit/deps/cli/imports.wit
+++ b/bin/wit/deps/cli/imports.wit
@@ -1,20 +1,36 @@
-package wasi:cli@0.2.0;
+package wasi:cli@0.2.3;
 
+@since(version = 0.2.0)
 world imports {
-  include wasi:clocks/imports@0.2.0;
-  include wasi:filesystem/imports@0.2.0;
-  include wasi:sockets/imports@0.2.0;
-  include wasi:random/imports@0.2.0;
-  include wasi:io/imports@0.2.0;
+  @since(version = 0.2.0)
+  include wasi:clocks/imports@0.2.3;
+  @since(version = 0.2.0)
+  include wasi:filesystem/imports@0.2.3;
+  @since(version = 0.2.0)
+  include wasi:sockets/imports@0.2.3;
+  @since(version = 0.2.0)
+  include wasi:random/imports@0.2.3;
+  @since(version = 0.2.0)
+  include wasi:io/imports@0.2.3;
 
+  @since(version = 0.2.0)
   import environment;
+  @since(version = 0.2.0)
   import exit;
+  @since(version = 0.2.0)
   import stdin;
+  @since(version = 0.2.0)
   import stdout;
+  @since(version = 0.2.0)
   import stderr;
+  @since(version = 0.2.0)
   import terminal-input;
+  @since(version = 0.2.0)
   import terminal-output;
+  @since(version = 0.2.0)
   import terminal-stdin;
+  @since(version = 0.2.0)
   import terminal-stdout;
+  @since(version = 0.2.0)
   import terminal-stderr;
 }

--- a/bin/wit/deps/cli/run.wit
+++ b/bin/wit/deps/cli/run.wit
@@ -1,4 +1,6 @@
+@since(version = 0.2.0)
 interface run {
   /// Run the program.
+  @since(version = 0.2.0)
   run: func() -> result;
 }

--- a/bin/wit/deps/cli/stdio.wit
+++ b/bin/wit/deps/cli/stdio.wit
@@ -1,17 +1,26 @@
+@since(version = 0.2.0)
 interface stdin {
-  use wasi:io/streams@0.2.0.{input-stream};
+  @since(version = 0.2.0)
+  use wasi:io/streams@0.2.3.{input-stream};
 
+  @since(version = 0.2.0)
   get-stdin: func() -> input-stream;
 }
 
+@since(version = 0.2.0)
 interface stdout {
-  use wasi:io/streams@0.2.0.{output-stream};
+  @since(version = 0.2.0)
+  use wasi:io/streams@0.2.3.{output-stream};
 
+  @since(version = 0.2.0)
   get-stdout: func() -> output-stream;
 }
 
+@since(version = 0.2.0)
 interface stderr {
-  use wasi:io/streams@0.2.0.{output-stream};
+  @since(version = 0.2.0)
+  use wasi:io/streams@0.2.3.{output-stream};
 
+  @since(version = 0.2.0)
   get-stderr: func() -> output-stream;
 }

--- a/bin/wit/deps/cli/terminal.wit
+++ b/bin/wit/deps/cli/terminal.wit
@@ -3,8 +3,10 @@
 /// In the future, this may include functions for disabling echoing,
 /// disabling input buffering so that keyboard events are sent through
 /// immediately, querying supported features, and so on.
+@since(version = 0.2.0)
 interface terminal-input {
     /// The input side of a terminal.
+    @since(version = 0.2.0)
     resource terminal-input;
 }
 
@@ -13,37 +15,48 @@ interface terminal-input {
 /// In the future, this may include functions for querying the terminal
 /// size, being notified of terminal size changes, querying supported
 /// features, and so on.
+@since(version = 0.2.0)
 interface terminal-output {
     /// The output side of a terminal.
+    @since(version = 0.2.0)
     resource terminal-output;
 }
 
 /// An interface providing an optional `terminal-input` for stdin as a
 /// link-time authority.
+@since(version = 0.2.0)
 interface terminal-stdin {
+    @since(version = 0.2.0)
     use terminal-input.{terminal-input};
 
     /// If stdin is connected to a terminal, return a `terminal-input` handle
     /// allowing further interaction with it.
+    @since(version = 0.2.0)
     get-terminal-stdin: func() -> option<terminal-input>;
 }
 
 /// An interface providing an optional `terminal-output` for stdout as a
 /// link-time authority.
+@since(version = 0.2.0)
 interface terminal-stdout {
+    @since(version = 0.2.0)
     use terminal-output.{terminal-output};
 
     /// If stdout is connected to a terminal, return a `terminal-output` handle
     /// allowing further interaction with it.
+    @since(version = 0.2.0)
     get-terminal-stdout: func() -> option<terminal-output>;
 }
 
 /// An interface providing an optional `terminal-output` for stderr as a
 /// link-time authority.
+@since(version = 0.2.0)
 interface terminal-stderr {
+    @since(version = 0.2.0)
     use terminal-output.{terminal-output};
 
     /// If stderr is connected to a terminal, return a `terminal-output` handle
     /// allowing further interaction with it.
+    @since(version = 0.2.0)
     get-terminal-stderr: func() -> option<terminal-output>;
 }

--- a/bin/wit/deps/clocks/monotonic-clock.wit
+++ b/bin/wit/deps/clocks/monotonic-clock.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.0;
+package wasi:clocks@0.2.3;
 /// WASI Monotonic Clock is a clock API intended to let users measure elapsed
 /// time.
 ///
@@ -7,38 +7,43 @@ package wasi:clocks@0.2.0;
 ///
 /// A monotonic clock is a clock which has an unspecified initial value, and
 /// successive reads of the clock will produce non-decreasing values.
-///
-/// It is intended for measuring elapsed time.
+@since(version = 0.2.0)
 interface monotonic-clock {
-    use wasi:io/poll@0.2.0.{pollable};
+    @since(version = 0.2.0)
+    use wasi:io/poll@0.2.3.{pollable};
 
     /// An instant in time, in nanoseconds. An instant is relative to an
     /// unspecified initial value, and can only be compared to instances from
     /// the same monotonic-clock.
+    @since(version = 0.2.0)
     type instant = u64;
 
     /// A duration of time, in nanoseconds.
+    @since(version = 0.2.0)
     type duration = u64;
 
     /// Read the current value of the clock.
     ///
     /// The clock is monotonic, therefore calling this function repeatedly will
     /// produce a sequence of non-decreasing values.
+    @since(version = 0.2.0)
     now: func() -> instant;
 
     /// Query the resolution of the clock. Returns the duration of time
     /// corresponding to a clock tick.
+    @since(version = 0.2.0)
     resolution: func() -> duration;
 
     /// Create a `pollable` which will resolve once the specified instant
-    /// occured.
+    /// has occurred.
+    @since(version = 0.2.0)
     subscribe-instant: func(
         when: instant,
     ) -> pollable;
 
-    /// Create a `pollable` which will resolve once the given duration has
-    /// elapsed, starting at the time at which this function was called.
-    /// occured.
+    /// Create a `pollable` that will resolve after the specified duration has
+    /// elapsed from the time this function is invoked.
+    @since(version = 0.2.0)
     subscribe-duration: func(
         when: duration,
     ) -> pollable;

--- a/bin/wit/deps/clocks/timezone.wit
+++ b/bin/wit/deps/clocks/timezone.wit
@@ -1,0 +1,55 @@
+package wasi:clocks@0.2.3;
+
+@unstable(feature = clocks-timezone)
+interface timezone {
+    @unstable(feature = clocks-timezone)
+    use wall-clock.{datetime};
+
+    /// Return information needed to display the given `datetime`. This includes
+    /// the UTC offset, the time zone name, and a flag indicating whether
+    /// daylight saving time is active.
+    ///
+    /// If the timezone cannot be determined for the given `datetime`, return a
+    /// `timezone-display` for `UTC` with a `utc-offset` of 0 and no daylight
+    /// saving time.
+    @unstable(feature = clocks-timezone)
+    display: func(when: datetime) -> timezone-display;
+
+    /// The same as `display`, but only return the UTC offset.
+    @unstable(feature = clocks-timezone)
+    utc-offset: func(when: datetime) -> s32;
+
+    /// Information useful for displaying the timezone of a specific `datetime`.
+    ///
+    /// This information may vary within a single `timezone` to reflect daylight
+    /// saving time adjustments.
+    @unstable(feature = clocks-timezone)
+    record timezone-display {
+        /// The number of seconds difference between UTC time and the local
+        /// time of the timezone.
+        ///
+        /// The returned value will always be less than 86400 which is the
+        /// number of seconds in a day (24*60*60).
+        ///
+        /// In implementations that do not expose an actual time zone, this
+        /// should return 0.
+        utc-offset: s32,
+
+        /// The abbreviated name of the timezone to display to a user. The name
+        /// `UTC` indicates Coordinated Universal Time. Otherwise, this should
+        /// reference local standards for the name of the time zone.
+        ///
+        /// In implementations that do not expose an actual time zone, this
+        /// should be the string `UTC`.
+        ///
+        /// In time zones that do not have an applicable name, a formatted
+        /// representation of the UTC offset may be returned, such as `-04:00`.
+        name: string,
+
+        /// Whether daylight saving time is active.
+        ///
+        /// In implementations that do not expose an actual time zone, this
+        /// should return false.
+        in-daylight-saving-time: bool,
+    }
+}

--- a/bin/wit/deps/clocks/wall-clock.wit
+++ b/bin/wit/deps/clocks/wall-clock.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.0;
+package wasi:clocks@0.2.3;
 /// WASI Wall Clock is a clock API intended to let users query the current
 /// time. The name "wall" makes an analogy to a "clock on the wall", which
 /// is not necessarily monotonic as it may be reset.
@@ -13,8 +13,10 @@ package wasi:clocks@0.2.0;
 /// monotonic, making it unsuitable for measuring elapsed time.
 ///
 /// It is intended for reporting the current date and time for humans.
+@since(version = 0.2.0)
 interface wall-clock {
     /// A time and date in seconds plus nanoseconds.
+    @since(version = 0.2.0)
     record datetime {
         seconds: u64,
         nanoseconds: u32,
@@ -33,10 +35,12 @@ interface wall-clock {
     ///
     /// [POSIX's Seconds Since the Epoch]: https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xbd_chap04.html#tag_21_04_16
     /// [Unix Time]: https://en.wikipedia.org/wiki/Unix_time
+    @since(version = 0.2.0)
     now: func() -> datetime;
 
     /// Query the resolution of the clock.
     ///
     /// The nanoseconds field of the output is always less than 1000000000.
+    @since(version = 0.2.0)
     resolution: func() -> datetime;
 }

--- a/bin/wit/deps/clocks/world.wit
+++ b/bin/wit/deps/clocks/world.wit
@@ -1,6 +1,11 @@
-package wasi:clocks@0.2.0;
+package wasi:clocks@0.2.3;
 
+@since(version = 0.2.0)
 world imports {
+    @since(version = 0.2.0)
     import monotonic-clock;
+    @since(version = 0.2.0)
     import wall-clock;
+    @unstable(feature = clocks-timezone)
+    import timezone;
 }

--- a/bin/wit/deps/filesystem/preopens.wit
+++ b/bin/wit/deps/filesystem/preopens.wit
@@ -1,8 +1,11 @@
-package wasi:filesystem@0.2.0;
+package wasi:filesystem@0.2.3;
 
+@since(version = 0.2.0)
 interface preopens {
+    @since(version = 0.2.0)
     use types.{descriptor};
 
-    /// Return the set of preopened directories, and their path.
+    /// Return the set of preopened directories, and their paths.
+    @since(version = 0.2.0)
     get-directories: func() -> list<tuple<descriptor, string>>;
 }

--- a/bin/wit/deps/filesystem/types.wit
+++ b/bin/wit/deps/filesystem/types.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.0;
+package wasi:filesystem@0.2.3;
 /// WASI filesystem is a filesystem API primarily intended to let users run WASI
 /// programs that access their files on their existing filesystems, without
 /// significant overhead.
@@ -23,16 +23,21 @@ package wasi:filesystem@0.2.0;
 /// [WASI filesystem path resolution].
 ///
 /// [WASI filesystem path resolution]: https://github.com/WebAssembly/wasi-filesystem/blob/main/path-resolution.md
+@since(version = 0.2.0)
 interface types {
-    use wasi:io/streams@0.2.0.{input-stream, output-stream, error};
-    use wasi:clocks/wall-clock@0.2.0.{datetime};
+    @since(version = 0.2.0)
+    use wasi:io/streams@0.2.3.{input-stream, output-stream, error};
+    @since(version = 0.2.0)
+    use wasi:clocks/wall-clock@0.2.3.{datetime};
 
     /// File size or length of a region within a file.
+    @since(version = 0.2.0)
     type filesize = u64;
 
     /// The type of a filesystem object referenced by a descriptor.
     ///
     /// Note: This was called `filetype` in earlier versions of WASI.
+    @since(version = 0.2.0)
     enum descriptor-type {
         /// The type of the descriptor or file is unknown or is different from
         /// any of the other types specified.
@@ -56,6 +61,7 @@ interface types {
     /// Descriptor flags.
     ///
     /// Note: This was called `fdflags` in earlier versions of WASI.
+    @since(version = 0.2.0)
     flags descriptor-flags {
         /// Read mode: Data can be read.
         read,
@@ -77,7 +83,7 @@ interface types {
         /// WASI. At this time, it should be interpreted as a request, and not a
         /// requirement.
         data-integrity-sync,
-        /// Requests that reads be performed at the same level of integrety
+        /// Requests that reads be performed at the same level of integrity
         /// requested for writes. This is similar to `O_RSYNC` in POSIX.
         ///
         /// The precise semantics of this operation have not yet been defined for
@@ -99,6 +105,7 @@ interface types {
     /// File attributes.
     ///
     /// Note: This was called `filestat` in earlier versions of WASI.
+    @since(version = 0.2.0)
     record descriptor-stat {
         /// File type.
         %type: descriptor-type,
@@ -125,6 +132,7 @@ interface types {
     }
 
     /// Flags determining the method of how paths are resolved.
+    @since(version = 0.2.0)
     flags path-flags {
         /// As long as the resolved path corresponds to a symbolic link, it is
         /// expanded.
@@ -132,6 +140,7 @@ interface types {
     }
 
     /// Open flags used by `open-at`.
+    @since(version = 0.2.0)
     flags open-flags {
         /// Create file if it does not exist, similar to `O_CREAT` in POSIX.
         create,
@@ -144,9 +153,11 @@ interface types {
     }
 
     /// Number of hard links to an inode.
+    @since(version = 0.2.0)
     type link-count = u64;
 
     /// When setting a timestamp, this gives the value to set it to.
+    @since(version = 0.2.0)
     variant new-timestamp {
         /// Leave the timestamp set to its previous value.
         no-change,
@@ -248,6 +259,7 @@ interface types {
     }
 
     /// File or memory access pattern advisory information.
+    @since(version = 0.2.0)
     enum advice {
         /// The application has no advice to give on its behavior with respect
         /// to the specified data.
@@ -271,6 +283,7 @@ interface types {
 
     /// A 128-bit hash value, split into parts because wasm doesn't have a
     /// 128-bit integer type.
+    @since(version = 0.2.0)
     record metadata-hash-value {
        /// 64 bits of a 128-bit hash value.
        lower: u64,
@@ -281,6 +294,7 @@ interface types {
     /// A descriptor is a reference to a filesystem object, which may be a file,
     /// directory, named pipe, special file, or other object on which filesystem
     /// calls may be made.
+    @since(version = 0.2.0)
     resource descriptor {
         /// Return a stream for reading from a file, if available.
         ///
@@ -290,6 +304,7 @@ interface types {
         /// file and they do not interfere with each other.
         ///
         /// Note: This allows using `read-stream`, which is similar to `read` in POSIX.
+        @since(version = 0.2.0)
         read-via-stream: func(
             /// The offset within the file at which to start reading.
             offset: filesize,
@@ -301,6 +316,7 @@ interface types {
         ///
         /// Note: This allows using `write-stream`, which is similar to `write` in
         /// POSIX.
+        @since(version = 0.2.0)
         write-via-stream: func(
             /// The offset within the file at which to start writing.
             offset: filesize,
@@ -311,12 +327,14 @@ interface types {
         /// May fail with an error-code describing why the file cannot be appended.
         ///
         /// Note: This allows using `write-stream`, which is similar to `write` with
-        /// `O_APPEND` in in POSIX.
+        /// `O_APPEND` in POSIX.
+        @since(version = 0.2.0)
         append-via-stream: func() -> result<output-stream, error-code>;
 
         /// Provide file advisory information on a descriptor.
         ///
         /// This is similar to `posix_fadvise` in POSIX.
+        @since(version = 0.2.0)
         advise: func(
             /// The offset within the file to which the advisory applies.
             offset: filesize,
@@ -332,6 +350,7 @@ interface types {
         /// opened for writing.
         ///
         /// Note: This is similar to `fdatasync` in POSIX.
+        @since(version = 0.2.0)
         sync-data: func() -> result<_, error-code>;
 
         /// Get flags associated with a descriptor.
@@ -340,6 +359,7 @@ interface types {
         ///
         /// Note: This returns the value that was the `fs_flags` value returned
         /// from `fdstat_get` in earlier versions of WASI.
+        @since(version = 0.2.0)
         get-flags: func() -> result<descriptor-flags, error-code>;
 
         /// Get the dynamic type of a descriptor.
@@ -352,12 +372,14 @@ interface types {
         ///
         /// Note: This returns the value that was the `fs_filetype` value returned
         /// from `fdstat_get` in earlier versions of WASI.
+        @since(version = 0.2.0)
         get-type: func() -> result<descriptor-type, error-code>;
 
         /// Adjust the size of an open file. If this increases the file's size, the
         /// extra bytes are filled with zeros.
         ///
         /// Note: This was called `fd_filestat_set_size` in earlier versions of WASI.
+        @since(version = 0.2.0)
         set-size: func(size: filesize) -> result<_, error-code>;
 
         /// Adjust the timestamps of an open file or directory.
@@ -365,6 +387,7 @@ interface types {
         /// Note: This is similar to `futimens` in POSIX.
         ///
         /// Note: This was called `fd_filestat_set_times` in earlier versions of WASI.
+        @since(version = 0.2.0)
         set-times: func(
             /// The desired values of the data access timestamp.
             data-access-timestamp: new-timestamp,
@@ -383,6 +406,7 @@ interface types {
         /// In the future, this may change to return a `stream<u8, error-code>`.
         ///
         /// Note: This is similar to `pread` in POSIX.
+        @since(version = 0.2.0)
         read: func(
             /// The maximum number of bytes to read.
             length: filesize,
@@ -399,6 +423,7 @@ interface types {
         /// In the future, this may change to take a `stream<u8, error-code>`.
         ///
         /// Note: This is similar to `pwrite` in POSIX.
+        @since(version = 0.2.0)
         write: func(
             /// Data to write
             buffer: list<u8>,
@@ -415,6 +440,7 @@ interface types {
         /// This always returns a new stream which starts at the beginning of the
         /// directory. Multiple streams may be active on the same directory, and they
         /// do not interfere with each other.
+        @since(version = 0.2.0)
         read-directory: func() -> result<directory-entry-stream, error-code>;
 
         /// Synchronize the data and metadata of a file to disk.
@@ -423,11 +449,13 @@ interface types {
         /// opened for writing.
         ///
         /// Note: This is similar to `fsync` in POSIX.
+        @since(version = 0.2.0)
         sync: func() -> result<_, error-code>;
 
         /// Create a directory.
         ///
         /// Note: This is similar to `mkdirat` in POSIX.
+        @since(version = 0.2.0)
         create-directory-at: func(
             /// The relative path at which to create the directory.
             path: string,
@@ -442,6 +470,7 @@ interface types {
         /// modified, use `metadata-hash`.
         ///
         /// Note: This was called `fd_filestat_get` in earlier versions of WASI.
+        @since(version = 0.2.0)
         stat: func() -> result<descriptor-stat, error-code>;
 
         /// Return the attributes of a file or directory.
@@ -451,6 +480,7 @@ interface types {
         /// discussion of alternatives.
         ///
         /// Note: This was called `path_filestat_get` in earlier versions of WASI.
+        @since(version = 0.2.0)
         stat-at: func(
             /// Flags determining the method of how the path is resolved.
             path-flags: path-flags,
@@ -464,6 +494,7 @@ interface types {
         ///
         /// Note: This was called `path_filestat_set_times` in earlier versions of
         /// WASI.
+        @since(version = 0.2.0)
         set-times-at: func(
             /// Flags determining the method of how the path is resolved.
             path-flags: path-flags,
@@ -478,6 +509,7 @@ interface types {
         /// Create a hard link.
         ///
         /// Note: This is similar to `linkat` in POSIX.
+        @since(version = 0.2.0)
         link-at: func(
             /// Flags determining the method of how the path is resolved.
             old-path-flags: path-flags,
@@ -491,12 +523,6 @@ interface types {
 
         /// Open a file or directory.
         ///
-        /// The returned descriptor is not guaranteed to be the lowest-numbered
-        /// descriptor not currently open/ it is randomized to prevent applications
-        /// from depending on making assumptions about indexes, since this is
-        /// error-prone in multi-threaded contexts. The returned descriptor is
-        /// guaranteed to be less than 2**31.
-        ///
         /// If `flags` contains `descriptor-flags::mutate-directory`, and the base
         /// descriptor doesn't have `descriptor-flags::mutate-directory` set,
         /// `open-at` fails with `error-code::read-only`.
@@ -507,6 +533,7 @@ interface types {
         /// `error-code::read-only`.
         ///
         /// Note: This is similar to `openat` in POSIX.
+        @since(version = 0.2.0)
         open-at: func(
             /// Flags determining the method of how the path is resolved.
             path-flags: path-flags,
@@ -524,6 +551,7 @@ interface types {
         /// filesystem, this function fails with `error-code::not-permitted`.
         ///
         /// Note: This is similar to `readlinkat` in POSIX.
+        @since(version = 0.2.0)
         readlink-at: func(
             /// The relative path of the symbolic link from which to read.
             path: string,
@@ -534,6 +562,7 @@ interface types {
         /// Return `error-code::not-empty` if the directory is not empty.
         ///
         /// Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
+        @since(version = 0.2.0)
         remove-directory-at: func(
             /// The relative path to a directory to remove.
             path: string,
@@ -542,6 +571,7 @@ interface types {
         /// Rename a filesystem object.
         ///
         /// Note: This is similar to `renameat` in POSIX.
+        @since(version = 0.2.0)
         rename-at: func(
             /// The relative source path of the file or directory to rename.
             old-path: string,
@@ -557,6 +587,7 @@ interface types {
         /// `error-code::not-permitted`.
         ///
         /// Note: This is similar to `symlinkat` in POSIX.
+        @since(version = 0.2.0)
         symlink-at: func(
             /// The contents of the symbolic link.
             old-path: string,
@@ -568,6 +599,7 @@ interface types {
         ///
         /// Return `error-code::is-directory` if the path refers to a directory.
         /// Note: This is similar to `unlinkat(fd, path, 0)` in POSIX.
+        @since(version = 0.2.0)
         unlink-file-at: func(
             /// The relative path to a file to unlink.
             path: string,
@@ -579,6 +611,7 @@ interface types {
         /// same device (`st_dev`) and inode (`st_ino` or `d_ino`) numbers.
         /// wasi-filesystem does not expose device and inode numbers, so this function
         /// may be used instead.
+        @since(version = 0.2.0)
         is-same-object: func(other: borrow<descriptor>) -> bool;
 
         /// Return a hash of the metadata associated with a filesystem object referred
@@ -590,7 +623,7 @@ interface types {
         /// replaced. It may also include a secret value chosen by the
         /// implementation and not otherwise exposed.
         ///
-        /// Implementations are encourated to provide the following properties:
+        /// Implementations are encouraged to provide the following properties:
         ///
         ///  - If the file is not modified or replaced, the computed hash value should
         ///    usually not change.
@@ -600,12 +633,14 @@ interface types {
         ///    computed hash.
         ///
         /// However, none of these is required.
+        @since(version = 0.2.0)
         metadata-hash: func() -> result<metadata-hash-value, error-code>;
 
         /// Return a hash of the metadata associated with a filesystem object referred
         /// to by a directory descriptor and a relative path.
         ///
         /// This performs the same hash computation as `metadata-hash`.
+        @since(version = 0.2.0)
         metadata-hash-at: func(
             /// Flags determining the method of how the path is resolved.
             path-flags: path-flags,
@@ -615,8 +650,10 @@ interface types {
     }
 
     /// A stream of directory entries.
+    @since(version = 0.2.0)
     resource directory-entry-stream {
         /// Read a single directory entry from a `directory-entry-stream`.
+        @since(version = 0.2.0)
         read-directory-entry: func() -> result<option<directory-entry>, error-code>;
     }
 
@@ -630,5 +667,6 @@ interface types {
     ///
     /// Note that this function is fallible because not all stream-related
     /// errors are filesystem-related errors.
+    @since(version = 0.2.0)
     filesystem-error-code: func(err: borrow<error>) -> option<error-code>;
 }

--- a/bin/wit/deps/filesystem/world.wit
+++ b/bin/wit/deps/filesystem/world.wit
@@ -1,6 +1,9 @@
-package wasi:filesystem@0.2.0;
+package wasi:filesystem@0.2.3;
 
+@since(version = 0.2.0)
 world imports {
+    @since(version = 0.2.0)
     import types;
+    @since(version = 0.2.0)
     import preopens;
 }

--- a/bin/wit/deps/http/handler.wit
+++ b/bin/wit/deps/http/handler.wit
@@ -1,6 +1,8 @@
 /// This interface defines a handler of incoming HTTP Requests. It should
 /// be exported by components which can respond to HTTP Requests.
+@since(version = 0.2.0)
 interface incoming-handler {
+  @since(version = 0.2.0)
   use types.{incoming-request, response-outparam};
 
   /// This function is invoked with an incoming HTTP Request, and a resource
@@ -13,6 +15,7 @@ interface incoming-handler {
   /// The implementor of this function must write a response to the
   /// `response-outparam` before returning, or else the caller will respond
   /// with an error on its behalf.
+  @since(version = 0.2.0)
   handle: func(
     request: incoming-request,
     response-out: response-outparam
@@ -21,7 +24,9 @@ interface incoming-handler {
 
 /// This interface defines a handler of outgoing HTTP Requests. It should be
 /// imported by components which wish to make HTTP Requests.
+@since(version = 0.2.0)
 interface outgoing-handler {
+  @since(version = 0.2.0)
   use types.{
     outgoing-request, request-options, future-incoming-response, error-code
   };
@@ -36,6 +41,7 @@ interface outgoing-handler {
   /// This function may return an error if the `outgoing-request` is invalid
   /// or not allowed to be made. Otherwise, protocol errors are reported
   /// through the `future-incoming-response`.
+  @since(version = 0.2.0)
   handle: func(
     request: outgoing-request,
     options: option<request-options>

--- a/bin/wit/deps/http/proxy.wit
+++ b/bin/wit/deps/http/proxy.wit
@@ -1,32 +1,50 @@
-package wasi:http@0.2.0;
+package wasi:http@0.2.3;
 
-/// The `wasi:http/proxy` world captures a widely-implementable intersection of
-/// hosts that includes HTTP forward and reverse proxies. Components targeting
-/// this world may concurrently stream in and out any number of incoming and
-/// outgoing HTTP requests.
-world proxy {
+/// The `wasi:http/imports` world imports all the APIs for HTTP proxies.
+/// It is intended to be `include`d in other worlds.
+@since(version = 0.2.0)
+world imports {
   /// HTTP proxies have access to time and randomness.
-  include wasi:clocks/imports@0.2.0;
-  import wasi:random/random@0.2.0;
+  @since(version = 0.2.0)
+  import wasi:clocks/monotonic-clock@0.2.3;
+  @since(version = 0.2.0)
+  import wasi:clocks/wall-clock@0.2.3;
+  @since(version = 0.2.0)
+  import wasi:random/random@0.2.3;
 
   /// Proxies have standard output and error streams which are expected to
   /// terminate in a developer-facing console provided by the host.
-  import wasi:cli/stdout@0.2.0;
-  import wasi:cli/stderr@0.2.0;
+  @since(version = 0.2.0)
+  import wasi:cli/stdout@0.2.3;
+  @since(version = 0.2.0)
+  import wasi:cli/stderr@0.2.3;
 
   /// TODO: this is a temporary workaround until component tooling is able to
   /// gracefully handle the absence of stdin. Hosts must return an eof stream
   /// for this import, which is what wasi-libc + tooling will do automatically
   /// when this import is properly removed.
-  import wasi:cli/stdin@0.2.0;
+  @since(version = 0.2.0)
+  import wasi:cli/stdin@0.2.3;
 
   /// This is the default handler to use when user code simply wants to make an
   /// HTTP request (e.g., via `fetch()`).
+  @since(version = 0.2.0)
   import outgoing-handler;
+}
+
+/// The `wasi:http/proxy` world captures a widely-implementable intersection of
+/// hosts that includes HTTP forward and reverse proxies. Components targeting
+/// this world may concurrently stream in and out any number of incoming and
+/// outgoing HTTP requests.
+@since(version = 0.2.0)
+world proxy {
+  @since(version = 0.2.0)
+  include imports;
 
   /// The host delivers incoming HTTP requests to a component by calling the
   /// `handle` function of this exported interface. A host may arbitrarily reuse
   /// or not reuse component instance when delivering incoming HTTP requests and
   /// thus a component must be able to handle 0..N calls to `handle`.
+  @since(version = 0.2.0)
   export incoming-handler;
 }

--- a/bin/wit/deps/http/types.wit
+++ b/bin/wit/deps/http/types.wit
@@ -1,13 +1,19 @@
 /// This interface defines all of the types and methods for implementing
 /// HTTP Requests and Responses, both incoming and outgoing, as well as
 /// their headers, trailers, and bodies.
+@since(version = 0.2.0)
 interface types {
-  use wasi:clocks/monotonic-clock@0.2.0.{duration};
-  use wasi:io/streams@0.2.0.{input-stream, output-stream};
-  use wasi:io/error@0.2.0.{error as io-error};
-  use wasi:io/poll@0.2.0.{pollable};
+  @since(version = 0.2.0)
+  use wasi:clocks/monotonic-clock@0.2.3.{duration};
+  @since(version = 0.2.0)
+  use wasi:io/streams@0.2.3.{input-stream, output-stream};
+  @since(version = 0.2.0)
+  use wasi:io/error@0.2.3.{error as io-error};
+  @since(version = 0.2.0)
+  use wasi:io/poll@0.2.3.{pollable};
 
   /// This type corresponds to HTTP standard Methods.
+  @since(version = 0.2.0)
   variant method {
     get,
     head,
@@ -22,6 +28,7 @@ interface types {
   }
 
   /// This type corresponds to HTTP standard Related Schemes.
+  @since(version = 0.2.0)
   variant scheme {
     HTTP,
     HTTPS,
@@ -29,7 +36,8 @@ interface types {
   }
 
   /// These cases are inspired by the IANA HTTP Proxy Error Types:
-  ///   https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types
+  ///   <https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types>
+  @since(version = 0.2.0)
   variant error-code {
     DNS-timeout,
     DNS-error(DNS-error-payload),
@@ -78,18 +86,21 @@ interface types {
   }
 
   /// Defines the case payload type for `DNS-error` above:
+  @since(version = 0.2.0)
   record DNS-error-payload {
     rcode: option<string>,
     info-code: option<u16>
   }
 
   /// Defines the case payload type for `TLS-alert-received` above:
+  @since(version = 0.2.0)
   record TLS-alert-received-payload {
     alert-id: option<u8>,
     alert-message: option<string>
   }
 
   /// Defines the case payload type for `HTTP-response-{header,trailer}-size` above:
+  @since(version = 0.2.0)
   record field-size-payload {
     field-name: option<string>,
     field-size: option<u32>
@@ -106,17 +117,19 @@ interface types {
   ///
   /// Note that this function is fallible because not all io-errors are
   /// http-related errors.
+  @since(version = 0.2.0)
   http-error-code: func(err: borrow<io-error>) -> option<error-code>;
 
   /// This type enumerates the different kinds of errors that may occur when
   /// setting or appending to a `fields` resource.
+  @since(version = 0.2.0)
   variant header-error {
-    /// This error indicates that a `field-key` or `field-value` was
+    /// This error indicates that a `field-name` or `field-value` was
     /// syntactically invalid when used with an operation that sets headers in a
     /// `fields`.
     invalid-syntax,
 
-    /// This error indicates that a forbidden `field-key` was used when trying
+    /// This error indicates that a forbidden `field-name` was used when trying
     /// to set a header in a `fields`.
     forbidden,
 
@@ -125,12 +138,29 @@ interface types {
     immutable,
   }
 
+  /// Field names are always strings.
+  ///
+  /// Field names should always be treated as case insensitive by the `fields`
+  /// resource for the purposes of equality checking.
+  @since(version = 0.2.1)
+  type field-name = field-key;
+
   /// Field keys are always strings.
+  ///
+  /// Field keys should always be treated as case insensitive by the `fields`
+  /// resource for the purposes of equality checking.
+  /// 
+  /// # Deprecation
+  /// 
+  /// This type has been deprecated in favor of the `field-name` type.
+  @since(version = 0.2.0)
+  @deprecated(version = 0.2.2)
   type field-key = string;
 
   /// Field values should always be ASCII strings. However, in
   /// reality, HTTP implementations often have to interpret malformed values,
   /// so they are provided as a list of bytes.
+  @since(version = 0.2.0)
   type field-value = list<u8>;
 
   /// This following block defines the `fields` resource which corresponds to
@@ -143,93 +173,120 @@ interface types {
   /// `incoming-request.headers`, `outgoing-request.headers`) might be be
   /// immutable. In an immutable fields, the `set`, `append`, and `delete`
   /// operations will fail with `header-error.immutable`.
+  @since(version = 0.2.0)
   resource fields {
 
     /// Construct an empty HTTP Fields.
     ///
     /// The resulting `fields` is mutable.
+    @since(version = 0.2.0)
     constructor();
 
     /// Construct an HTTP Fields.
     ///
     /// The resulting `fields` is mutable.
     ///
-    /// The list represents each key-value pair in the Fields. Keys
+    /// The list represents each name-value pair in the Fields. Names
     /// which have multiple values are represented by multiple entries in this
-    /// list with the same key.
+    /// list with the same name.
     ///
-    /// The tuple is a pair of the field key, represented as a string, and
-    /// Value, represented as a list of bytes. In a valid Fields, all keys
-    /// and values are valid UTF-8 strings. However, values are not always
-    /// well-formed, so they are represented as a raw list of bytes.
+    /// The tuple is a pair of the field name, represented as a string, and
+    /// Value, represented as a list of bytes.
     ///
-    /// An error result will be returned if any header or value was
-    /// syntactically invalid, or if a header was forbidden.
+    /// An error result will be returned if any `field-name` or `field-value` is
+    /// syntactically invalid, or if a field is forbidden.
+    @since(version = 0.2.0)
     from-list: static func(
-      entries: list<tuple<field-key,field-value>>
+      entries: list<tuple<field-name,field-value>>
     ) -> result<fields, header-error>;
 
-    /// Get all of the values corresponding to a key. If the key is not present
-    /// in this `fields`, an empty list is returned. However, if the key is
-    /// present but empty, this is represented by a list with one or more
-    /// empty field-values present.
-    get: func(name: field-key) -> list<field-value>;
+    /// Get all of the values corresponding to a name. If the name is not present
+    /// in this `fields` or is syntactically invalid, an empty list is returned.
+    /// However, if the name is present but empty, this is represented by a list
+    /// with one or more empty field-values present.
+    @since(version = 0.2.0)
+    get: func(name: field-name) -> list<field-value>;
 
-    /// Returns `true` when the key is present in this `fields`. If the key is
+    /// Returns `true` when the name is present in this `fields`. If the name is
     /// syntactically invalid, `false` is returned.
-    has: func(name: field-key) -> bool;
+    @since(version = 0.2.0)
+    has: func(name: field-name) -> bool;
 
-    /// Set all of the values for a key. Clears any existing values for that
-    /// key, if they have been set.
+    /// Set all of the values for a name. Clears any existing values for that
+    /// name, if they have been set.
     ///
     /// Fails with `header-error.immutable` if the `fields` are immutable.
-    set: func(name: field-key, value: list<field-value>) -> result<_, header-error>;
+    ///
+    /// Fails with `header-error.invalid-syntax` if the `field-name` or any of
+    /// the `field-value`s are syntactically invalid.
+    @since(version = 0.2.0)
+    set: func(name: field-name, value: list<field-value>) -> result<_, header-error>;
 
-    /// Delete all values for a key. Does nothing if no values for the key
+    /// Delete all values for a name. Does nothing if no values for the name
     /// exist.
     ///
     /// Fails with `header-error.immutable` if the `fields` are immutable.
-    delete: func(name: field-key) -> result<_, header-error>;
+    ///
+    /// Fails with `header-error.invalid-syntax` if the `field-name` is
+    /// syntactically invalid.
+    @since(version = 0.2.0)
+    delete: func(name: field-name) -> result<_, header-error>;
 
-    /// Append a value for a key. Does not change or delete any existing
-    /// values for that key.
+    /// Append a value for a name. Does not change or delete any existing
+    /// values for that name.
     ///
     /// Fails with `header-error.immutable` if the `fields` are immutable.
-    append: func(name: field-key, value: field-value) -> result<_, header-error>;
-
-    /// Retrieve the full set of keys and values in the Fields. Like the
-    /// constructor, the list represents each key-value pair.
     ///
-    /// The outer list represents each key-value pair in the Fields. Keys
-    /// which have multiple values are represented by multiple entries in this
-    /// list with the same key.
-    entries: func() -> list<tuple<field-key,field-value>>;
+    /// Fails with `header-error.invalid-syntax` if the `field-name` or
+    /// `field-value` are syntactically invalid.
+    @since(version = 0.2.0)
+    append: func(name: field-name, value: field-value) -> result<_, header-error>;
 
-    /// Make a deep copy of the Fields. Equivelant in behavior to calling the
+    /// Retrieve the full set of names and values in the Fields. Like the
+    /// constructor, the list represents each name-value pair.
+    ///
+    /// The outer list represents each name-value pair in the Fields. Names
+    /// which have multiple values are represented by multiple entries in this
+    /// list with the same name.
+    ///
+    /// The names and values are always returned in the original casing and in
+    /// the order in which they will be serialized for transport.
+    @since(version = 0.2.0)
+    entries: func() -> list<tuple<field-name,field-value>>;
+
+    /// Make a deep copy of the Fields. Equivalent in behavior to calling the
     /// `fields` constructor on the return value of `entries`. The resulting
     /// `fields` is mutable.
+    @since(version = 0.2.0)
     clone: func() -> fields;
   }
 
   /// Headers is an alias for Fields.
+  @since(version = 0.2.0)
   type headers = fields;
 
   /// Trailers is an alias for Fields.
+  @since(version = 0.2.0)
   type trailers = fields;
 
   /// Represents an incoming HTTP Request.
+  @since(version = 0.2.0)
   resource incoming-request {
 
     /// Returns the method of the incoming request.
+    @since(version = 0.2.0)
     method: func() -> method;
 
     /// Returns the path with query parameters from the request, as a string.
+    @since(version = 0.2.0)
     path-with-query: func() -> option<string>;
 
     /// Returns the protocol scheme from the request.
+    @since(version = 0.2.0)
     scheme: func() -> option<scheme>;
 
-    /// Returns the authority from the request, if it was present.
+    /// Returns the authority of the Request's target URI, if present.
+    @since(version = 0.2.0)
     authority: func() -> option<string>;
 
     /// Get the `headers` associated with the request.
@@ -240,14 +297,17 @@ interface types {
     /// The `headers` returned are a child resource: it must be dropped before
     /// the parent `incoming-request` is dropped. Dropping this
     /// `incoming-request` before all children are dropped will trap.
+    @since(version = 0.2.0)
     headers: func() -> headers;
 
     /// Gives the `incoming-body` associated with this request. Will only
     /// return success at most once, and subsequent calls will return error.
+    @since(version = 0.2.0)
     consume: func() -> result<incoming-body>;
   }
 
   /// Represents an outgoing HTTP Request.
+  @since(version = 0.2.0)
   resource outgoing-request {
 
     /// Construct a new `outgoing-request` with a default `method` of `GET`, and
@@ -260,6 +320,7 @@ interface types {
     /// and `authority`, or `headers` which are not permitted to be sent.
     /// It is the obligation of the `outgoing-handler.handle` implementation
     /// to reject invalid constructions of `outgoing-request`.
+    @since(version = 0.2.0)
     constructor(
       headers: headers
     );
@@ -270,38 +331,47 @@ interface types {
     /// Returns success on the first call: the `outgoing-body` resource for
     /// this `outgoing-request` can be retrieved at most once. Subsequent
     /// calls will return error.
+    @since(version = 0.2.0)
     body: func() -> result<outgoing-body>;
 
     /// Get the Method for the Request.
+    @since(version = 0.2.0)
     method: func() -> method;
     /// Set the Method for the Request. Fails if the string present in a
     /// `method.other` argument is not a syntactically valid method.
+    @since(version = 0.2.0)
     set-method: func(method: method) -> result;
 
     /// Get the combination of the HTTP Path and Query for the Request.
     /// When `none`, this represents an empty Path and empty Query.
+    @since(version = 0.2.0)
     path-with-query: func() -> option<string>;
     /// Set the combination of the HTTP Path and Query for the Request.
     /// When `none`, this represents an empty Path and empty Query. Fails is the
     /// string given is not a syntactically valid path and query uri component.
+    @since(version = 0.2.0)
     set-path-with-query: func(path-with-query: option<string>) -> result;
 
     /// Get the HTTP Related Scheme for the Request. When `none`, the
     /// implementation may choose an appropriate default scheme.
+    @since(version = 0.2.0)
     scheme: func() -> option<scheme>;
     /// Set the HTTP Related Scheme for the Request. When `none`, the
     /// implementation may choose an appropriate default scheme. Fails if the
     /// string given is not a syntactically valid uri scheme.
+    @since(version = 0.2.0)
     set-scheme: func(scheme: option<scheme>) -> result;
 
-    /// Get the HTTP Authority for the Request. A value of `none` may be used
-    /// with Related Schemes which do not require an Authority. The HTTP and
+    /// Get the authority of the Request's target URI. A value of `none` may be used
+    /// with Related Schemes which do not require an authority. The HTTP and
     /// HTTPS schemes always require an authority.
+    @since(version = 0.2.0)
     authority: func() -> option<string>;
-    /// Set the HTTP Authority for the Request. A value of `none` may be used
-    /// with Related Schemes which do not require an Authority. The HTTP and
+    /// Set the authority of the Request's target URI. A value of `none` may be used
+    /// with Related Schemes which do not require an authority. The HTTP and
     /// HTTPS schemes always require an authority. Fails if the string given is
-    /// not a syntactically valid uri authority.
+    /// not a syntactically valid URI authority.
+    @since(version = 0.2.0)
     set-authority: func(authority: option<string>) -> result;
 
     /// Get the headers associated with the Request.
@@ -310,8 +380,9 @@ interface types {
     /// `delete` operations will fail with `header-error.immutable`.
     ///
     /// This headers resource is a child: it must be dropped before the parent
-    /// `outgoing-request` is dropped, or its ownership is transfered to
+    /// `outgoing-request` is dropped, or its ownership is transferred to
     /// another component by e.g. `outgoing-handler.handle`.
+    @since(version = 0.2.0)
     headers: func() -> headers;
   }
 
@@ -321,31 +392,39 @@ interface types {
   ///
   /// These timeouts are separate from any the user may use to bound a
   /// blocking call to `wasi:io/poll.poll`.
+  @since(version = 0.2.0)
   resource request-options {
     /// Construct a default `request-options` value.
+    @since(version = 0.2.0)
     constructor();
 
     /// The timeout for the initial connect to the HTTP Server.
+    @since(version = 0.2.0)
     connect-timeout: func() -> option<duration>;
 
     /// Set the timeout for the initial connect to the HTTP Server. An error
     /// return value indicates that this timeout is not supported.
+    @since(version = 0.2.0)
     set-connect-timeout: func(duration: option<duration>) -> result;
 
     /// The timeout for receiving the first byte of the Response body.
+    @since(version = 0.2.0)
     first-byte-timeout: func() -> option<duration>;
 
     /// Set the timeout for receiving the first byte of the Response body. An
     /// error return value indicates that this timeout is not supported.
+    @since(version = 0.2.0)
     set-first-byte-timeout: func(duration: option<duration>) -> result;
 
     /// The timeout for receiving subsequent chunks of bytes in the Response
     /// body stream.
+    @since(version = 0.2.0)
     between-bytes-timeout: func() -> option<duration>;
 
     /// Set the timeout for receiving subsequent chunks of bytes in the Response
     /// body stream. An error return value indicates that this timeout is not
     /// supported.
+    @since(version = 0.2.0)
     set-between-bytes-timeout: func(duration: option<duration>) -> result;
   }
 
@@ -354,6 +433,7 @@ interface types {
   /// This resource is used by the `wasi:http/incoming-handler` interface to
   /// allow a Response to be sent corresponding to the Request provided as the
   /// other argument to `incoming-handler.handle`.
+  @since(version = 0.2.0)
   resource response-outparam {
 
     /// Set the value of the `response-outparam` to either send a response,
@@ -365,6 +445,7 @@ interface types {
     ///
     /// The user may provide an `error` to `response` to allow the
     /// implementation determine how to respond with an HTTP error response.
+    @since(version = 0.2.0)
     set: static func(
       param: response-outparam,
       response: result<outgoing-response, error-code>,
@@ -372,12 +453,15 @@ interface types {
   }
 
   /// This type corresponds to the HTTP standard Status Code.
+  @since(version = 0.2.0)
   type status-code = u16;
 
   /// Represents an incoming HTTP Response.
+  @since(version = 0.2.0)
   resource incoming-response {
 
     /// Returns the status code from the incoming response.
+    @since(version = 0.2.0)
     status: func() -> status-code;
 
     /// Returns the headers from the incoming response.
@@ -387,10 +471,12 @@ interface types {
     ///
     /// This headers resource is a child: it must be dropped before the parent
     /// `incoming-response` is dropped.
+    @since(version = 0.2.0)
     headers: func() -> headers;
 
     /// Returns the incoming body. May be called at most once. Returns error
     /// if called additional times.
+    @since(version = 0.2.0)
     consume: func() -> result<incoming-body>;
   }
 
@@ -402,6 +488,7 @@ interface types {
   /// an `input-stream` and the delivery of trailers as a `future-trailers`,
   /// and ensures that the user of this interface may only be consuming either
   /// the body contents or waiting on trailers at any given time.
+  @since(version = 0.2.0)
   resource incoming-body {
 
     /// Returns the contents of the body, as a stream of bytes.
@@ -419,26 +506,30 @@ interface types {
     /// backpressure is to be applied when the user is consuming the body,
     /// and for that backpressure to not inhibit delivery of the trailers if
     /// the user does not read the entire body.
+    @since(version = 0.2.0)
     %stream: func() -> result<input-stream>;
 
     /// Takes ownership of `incoming-body`, and returns a `future-trailers`.
     /// This function will trap if the `input-stream` child is still alive.
+    @since(version = 0.2.0)
     finish: static func(this: incoming-body) -> future-trailers;
   }
 
-  /// Represents a future which may eventaully return trailers, or an error.
+  /// Represents a future which may eventually return trailers, or an error.
   ///
   /// In the case that the incoming HTTP Request or Response did not have any
   /// trailers, this future will resolve to the empty set of trailers once the
   /// complete Request or Response body has been received.
+  @since(version = 0.2.0)
   resource future-trailers {
 
     /// Returns a pollable which becomes ready when either the trailers have
-    /// been received, or an error has occured. When this pollable is ready,
+    /// been received, or an error has occurred. When this pollable is ready,
     /// the `get` method will return `some`.
+    @since(version = 0.2.0)
     subscribe: func() -> pollable;
 
-    /// Returns the contents of the trailers, or an error which occured,
+    /// Returns the contents of the trailers, or an error which occurred,
     /// once the future is ready.
     ///
     /// The outer `option` represents future readiness. Users can wait on this
@@ -450,17 +541,19 @@ interface types {
     ///
     /// The inner `result` represents that either the HTTP Request or Response
     /// body, as well as any trailers, were received successfully, or that an
-    /// error occured receiving them. The optional `trailers` indicates whether
+    /// error occurred receiving them. The optional `trailers` indicates whether
     /// or not trailers were present in the body.
     ///
     /// When some `trailers` are returned by this method, the `trailers`
     /// resource is immutable, and a child. Use of the `set`, `append`, or
     /// `delete` methods will return an error, and the resource must be
     /// dropped before the parent `future-trailers` is dropped.
+    @since(version = 0.2.0)
     get: func() -> option<result<result<option<trailers>, error-code>>>;
   }
 
   /// Represents an outgoing HTTP Response.
+  @since(version = 0.2.0)
   resource outgoing-response {
 
     /// Construct an `outgoing-response`, with a default `status-code` of `200`.
@@ -468,13 +561,16 @@ interface types {
     /// `set-status-code` method.
     ///
     /// * `headers` is the HTTP Headers for the Response.
+    @since(version = 0.2.0)
     constructor(headers: headers);
 
     /// Get the HTTP Status Code for the Response.
+    @since(version = 0.2.0)
     status-code: func() -> status-code;
 
     /// Set the HTTP Status Code for the Response. Fails if the status-code
     /// given is not a valid http status code.
+    @since(version = 0.2.0)
     set-status-code: func(status-code: status-code) -> result;
 
     /// Get the headers associated with the Request.
@@ -483,8 +579,9 @@ interface types {
     /// `delete` operations will fail with `header-error.immutable`.
     ///
     /// This headers resource is a child: it must be dropped before the parent
-    /// `outgoing-request` is dropped, or its ownership is transfered to
+    /// `outgoing-request` is dropped, or its ownership is transferred to
     /// another component by e.g. `outgoing-handler.handle`.
+    @since(version = 0.2.0)
     headers: func() -> headers;
 
     /// Returns the resource corresponding to the outgoing Body for this Response.
@@ -492,6 +589,7 @@ interface types {
     /// Returns success on the first call: the `outgoing-body` resource for
     /// this `outgoing-response` can be retrieved at most once. Subsequent
     /// calls will return error.
+    @since(version = 0.2.0)
     body: func() -> result<outgoing-body>;
   }
 
@@ -507,10 +605,11 @@ interface types {
   ///
   /// If the user code drops this resource, as opposed to calling the static
   /// method `finish`, the implementation should treat the body as incomplete,
-  /// and that an error has occured. The implementation should propogate this
+  /// and that an error has occurred. The implementation should propagate this
   /// error to the HTTP protocol by whatever means it has available,
   /// including: corrupting the body on the wire, aborting the associated
   /// Request, or sending a late status code for the Response.
+  @since(version = 0.2.0)
   resource outgoing-body {
 
     /// Returns a stream for writing the body contents.
@@ -522,6 +621,7 @@ interface types {
     /// Returns success on the first call: the `output-stream` resource for
     /// this `outgoing-body` may be retrieved at most once. Subsequent calls
     /// will return error.
+    @since(version = 0.2.0)
     write: func() -> result<output-stream>;
 
     /// Finalize an outgoing body, optionally providing trailers. This must be
@@ -533,21 +633,24 @@ interface types {
     /// constructed with a Content-Length header, and the contents written
     /// to the body (via `write`) does not match the value given in the
     /// Content-Length.
+    @since(version = 0.2.0)
     finish: static func(
       this: outgoing-body,
       trailers: option<trailers>
     ) -> result<_, error-code>;
   }
 
-  /// Represents a future which may eventaully return an incoming HTTP
+  /// Represents a future which may eventually return an incoming HTTP
   /// Response, or an error.
   ///
   /// This resource is returned by the `wasi:http/outgoing-handler` interface to
   /// provide the HTTP Response corresponding to the sent Request.
+  @since(version = 0.2.0)
   resource future-incoming-response {
     /// Returns a pollable which becomes ready when either the Response has
-    /// been received, or an error has occured. When this pollable is ready,
+    /// been received, or an error has occurred. When this pollable is ready,
     /// the `get` method will return `some`.
+    @since(version = 0.2.0)
     subscribe: func() -> pollable;
 
     /// Returns the incoming HTTP Response, or an error, once one is ready.
@@ -560,11 +663,11 @@ interface types {
     /// is `some`, and error on subsequent calls.
     ///
     /// The inner `result` represents that either the incoming HTTP Response
-    /// status and headers have recieved successfully, or that an error
-    /// occured. Errors may also occur while consuming the response body,
+    /// status and headers have received successfully, or that an error
+    /// occurred. Errors may also occur while consuming the response body,
     /// but those will be reported by the `incoming-body` and its
     /// `output-stream` child.
+    @since(version = 0.2.0)
     get: func() -> option<result<result<incoming-response, error-code>>>;
-
   }
 }

--- a/bin/wit/deps/io/error.wit
+++ b/bin/wit/deps/io/error.wit
@@ -1,6 +1,6 @@
-package wasi:io@0.2.0;
+package wasi:io@0.2.3;
 
-
+@since(version = 0.2.0)
 interface error {
     /// A resource which represents some error information.
     ///
@@ -11,16 +11,15 @@ interface error {
     /// `wasi:io/streams/stream-error` type.
     ///
     /// To provide more specific error information, other interfaces may
-    /// provide functions to further "downcast" this error into more specific
-    /// error information. For example, `error`s returned in streams derived
-    /// from filesystem types to be described using the filesystem's own
-    /// error-code type, using the function
-    /// `wasi:filesystem/types/filesystem-error-code`, which takes a parameter
-    /// `borrow<error>` and returns
-    /// `option<wasi:filesystem/types/error-code>`.
+    /// offer functions to "downcast" this error into more specific types. For example,
+    /// errors returned from streams derived from filesystem types can be described using
+    /// the filesystem's own error-code type. This is done using the function
+    /// `wasi:filesystem/types/filesystem-error-code`, which takes a `borrow<error>`
+    /// parameter and returns an `option<wasi:filesystem/types/error-code>`.
     ///
     /// The set of functions which can "downcast" an `error` into a more
     /// concrete type is open.
+    @since(version = 0.2.0)
     resource error {
         /// Returns a string that is suitable to assist humans in debugging
         /// this error.
@@ -29,6 +28,7 @@ interface error {
         /// It may change across platforms, hosts, or other implementation
         /// details. Parsing this string is a major platform-compatibility
         /// hazard.
+        @since(version = 0.2.0)
         to-debug-string: func() -> string;
     }
 }

--- a/bin/wit/deps/io/poll.wit
+++ b/bin/wit/deps/io/poll.wit
@@ -1,14 +1,17 @@
-package wasi:io@0.2.0;
+package wasi:io@0.2.3;
 
 /// A poll API intended to let users wait for I/O events on multiple handles
 /// at once.
+@since(version = 0.2.0)
 interface poll {
     /// `pollable` represents a single I/O event which may be ready, or not.
+    @since(version = 0.2.0)
     resource pollable {
 
       /// Return the readiness of a pollable. This function never blocks.
       ///
       /// Returns `true` when the pollable is ready, and `false` otherwise.
+      @since(version = 0.2.0)
       ready: func() -> bool;
 
       /// `block` returns immediately if the pollable is ready, and otherwise
@@ -16,6 +19,7 @@ interface poll {
       ///
       /// This function is equivalent to calling `poll.poll` on a list
       /// containing only this pollable.
+      @since(version = 0.2.0)
       block: func();
     }
 
@@ -27,8 +31,9 @@ interface poll {
     /// The result `list<u32>` contains one or more indices of handles in the
     /// argument list that is ready for I/O.
     ///
-    /// If the list contains more elements than can be indexed with a `u32`
-    /// value, this function traps.
+    /// This function traps if either:
+    /// - the list is empty, or:
+    /// - the list contains more elements than can be indexed with a `u32` value.
     ///
     /// A timeout can be implemented by adding a pollable from the
     /// wasi-clocks API to the list.
@@ -36,6 +41,7 @@ interface poll {
     /// This function does not return a `result`; polling in itself does not
     /// do any I/O so it doesn't fail. If any of the I/O sources identified by
     /// the pollables has an error, it is indicated by marking the source as
-    /// being reaedy for I/O.
+    /// being ready for I/O.
+    @since(version = 0.2.0)
     poll: func(in: list<borrow<pollable>>) -> list<u32>;
 }

--- a/bin/wit/deps/io/streams.wit
+++ b/bin/wit/deps/io/streams.wit
@@ -1,19 +1,26 @@
-package wasi:io@0.2.0;
+package wasi:io@0.2.3;
 
 /// WASI I/O is an I/O abstraction API which is currently focused on providing
 /// stream types.
 ///
 /// In the future, the component model is expected to add built-in stream types;
 /// when it does, they are expected to subsume this API.
+@since(version = 0.2.0)
 interface streams {
+    @since(version = 0.2.0)
     use error.{error};
+    @since(version = 0.2.0)
     use poll.{pollable};
 
     /// An error for input-stream and output-stream operations.
+    @since(version = 0.2.0)
     variant stream-error {
         /// The last operation (a write or flush) failed before completion.
         ///
         /// More information is available in the `error` payload.
+        ///
+        /// After this, the stream will be closed. All future operations return
+        /// `stream-error::closed`.
         last-operation-failed(error),
         /// The stream is closed: no more input will be accepted by the
         /// stream. A closed output-stream will return this error on all
@@ -29,6 +36,7 @@ interface streams {
     /// available, which could even be zero. To wait for data to be available,
     /// use the `subscribe` function to obtain a `pollable` which can be polled
     /// for using `wasi:io/poll`.
+    @since(version = 0.2.0)
     resource input-stream {
         /// Perform a non-blocking read from the stream.
         ///
@@ -56,6 +64,7 @@ interface streams {
         /// is not possible to allocate in wasm32, or not desirable to allocate as
         /// as a return value by the callee. The callee may return a list of bytes
         /// less than `len` in size while more bytes are available for reading.
+        @since(version = 0.2.0)
         read: func(
             /// The maximum number of bytes to read
             len: u64
@@ -63,6 +72,7 @@ interface streams {
 
         /// Read bytes from a stream, after blocking until at least one byte can
         /// be read. Except for blocking, behavior is identical to `read`.
+        @since(version = 0.2.0)
         blocking-read: func(
             /// The maximum number of bytes to read
             len: u64
@@ -72,6 +82,7 @@ interface streams {
         ///
         /// Behaves identical to `read`, except instead of returning a list
         /// of bytes, returns the number of bytes consumed from the stream.
+        @since(version = 0.2.0)
         skip: func(
             /// The maximum number of bytes to skip.
             len: u64,
@@ -79,6 +90,7 @@ interface streams {
 
         /// Skip bytes from a stream, after blocking until at least one byte
         /// can be skipped. Except for blocking behavior, identical to `skip`.
+        @since(version = 0.2.0)
         blocking-skip: func(
             /// The maximum number of bytes to skip.
             len: u64,
@@ -90,6 +102,7 @@ interface streams {
         /// The created `pollable` is a child resource of the `input-stream`.
         /// Implementations may trap if the `input-stream` is dropped before
         /// all derived `pollable`s created with this function are dropped.
+        @since(version = 0.2.0)
         subscribe: func() -> pollable;
     }
 
@@ -102,6 +115,11 @@ interface streams {
     /// promptly, which could even be zero. To wait for the stream to be ready to
     /// accept data, the `subscribe` function to obtain a `pollable` which can be
     /// polled for using `wasi:io/poll`.
+    ///
+    /// Dropping an `output-stream` while there's still an active write in
+    /// progress may result in the data being lost. Before dropping the stream,
+    /// be sure to fully flush your writes.
+    @since(version = 0.2.0)
     resource output-stream {
         /// Check readiness for writing. This function never blocks.
         ///
@@ -112,6 +130,7 @@ interface streams {
         /// When this function returns 0 bytes, the `subscribe` pollable will
         /// become ready when this function will report at least 1 byte, or an
         /// error.
+        @since(version = 0.2.0)
         check-write: func() -> result<u64, stream-error>;
 
         /// Perform a write. This function never blocks.
@@ -127,6 +146,7 @@ interface streams {
         ///
         /// returns Err(closed) without writing if the stream has closed since
         /// the last call to check-write provided a permit.
+        @since(version = 0.2.0)
         write: func(
             contents: list<u8>
         ) -> result<_, stream-error>;
@@ -155,6 +175,7 @@ interface streams {
         /// // Check for any errors that arose during `flush`
         /// let _ = this.check-write();         // eliding error handling
         /// ```
+        @since(version = 0.2.0)
         blocking-write-and-flush: func(
             contents: list<u8>
         ) -> result<_, stream-error>;
@@ -169,14 +190,16 @@ interface streams {
         /// writes (`check-write` will return `ok(0)`) until the flush has
         /// completed. The `subscribe` pollable will become ready when the
         /// flush has completed and the stream can accept more writes.
+        @since(version = 0.2.0)
         flush: func() -> result<_, stream-error>;
 
         /// Request to flush buffered output, and block until flush completes
         /// and stream is ready for writing again.
+        @since(version = 0.2.0)
         blocking-flush: func() -> result<_, stream-error>;
 
         /// Create a `pollable` which will resolve once the output-stream
-        /// is ready for more writing, or an error has occured. When this
+        /// is ready for more writing, or an error has occurred. When this
         /// pollable is ready, `check-write` will return `ok(n)` with n>0, or an
         /// error.
         ///
@@ -185,6 +208,7 @@ interface streams {
         /// The created `pollable` is a child resource of the `output-stream`.
         /// Implementations may trap if the `output-stream` is dropped before
         /// all derived `pollable`s created with this function are dropped.
+        @since(version = 0.2.0)
         subscribe: func() -> pollable;
 
         /// Write zeroes to a stream.
@@ -193,6 +217,7 @@ interface streams {
         /// preconditions (must use check-write first), but instead of
         /// passing a list of bytes, you simply pass the number of zero-bytes
         /// that should be written.
+        @since(version = 0.2.0)
         write-zeroes: func(
             /// The number of zero-bytes to write
             len: u64
@@ -222,6 +247,7 @@ interface streams {
         /// // Check for any errors that arose during `flush`
         /// let _ = this.check-write();         // eliding error handling
         /// ```
+        @since(version = 0.2.0)
         blocking-write-zeroes-and-flush: func(
             /// The number of zero-bytes to write
             len: u64
@@ -229,7 +255,7 @@ interface streams {
 
         /// Read from one stream and write to another.
         ///
-        /// The behavior of splice is equivelant to:
+        /// The behavior of splice is equivalent to:
         /// 1. calling `check-write` on the `output-stream`
         /// 2. calling `read` on the `input-stream` with the smaller of the
         /// `check-write` permitted length and the `len` provided to `splice`
@@ -240,6 +266,7 @@ interface streams {
         ///
         /// This function returns the number of bytes transferred; it may be less
         /// than `len`.
+        @since(version = 0.2.0)
         splice: func(
             /// The stream to read from
             src: borrow<input-stream>,
@@ -252,6 +279,7 @@ interface streams {
         /// This is similar to `splice`, except that it blocks until the
         /// `output-stream` is ready for writing, and the `input-stream`
         /// is ready for reading, before performing the `splice`.
+        @since(version = 0.2.0)
         blocking-splice: func(
             /// The stream to read from
             src: borrow<input-stream>,

--- a/bin/wit/deps/io/world.wit
+++ b/bin/wit/deps/io/world.wit
@@ -1,6 +1,10 @@
-package wasi:io@0.2.0;
+package wasi:io@0.2.3;
 
+@since(version = 0.2.0)
 world imports {
+    @since(version = 0.2.0)
     import streams;
+
+    @since(version = 0.2.0)
     import poll;
 }

--- a/bin/wit/deps/random/insecure-seed.wit
+++ b/bin/wit/deps/random/insecure-seed.wit
@@ -1,8 +1,9 @@
-package wasi:random@0.2.0;
+package wasi:random@0.2.3;
 /// The insecure-seed interface for seeding hash-map DoS resistance.
 ///
 /// It is intended to be portable at least between Unix-family platforms and
 /// Windows.
+@since(version = 0.2.0)
 interface insecure-seed {
     /// Return a 128-bit value that may contain a pseudo-random value.
     ///
@@ -21,5 +22,6 @@ interface insecure-seed {
     /// This will likely be changed to a value import, to prevent it from being
     /// called multiple times and potentially used for purposes other than DoS
     /// protection.
+    @since(version = 0.2.0)
     insecure-seed: func() -> tuple<u64, u64>;
 }

--- a/bin/wit/deps/random/insecure.wit
+++ b/bin/wit/deps/random/insecure.wit
@@ -1,8 +1,9 @@
-package wasi:random@0.2.0;
+package wasi:random@0.2.3;
 /// The insecure interface for insecure pseudo-random numbers.
 ///
 /// It is intended to be portable at least between Unix-family platforms and
 /// Windows.
+@since(version = 0.2.0)
 interface insecure {
     /// Return `len` insecure pseudo-random bytes.
     ///
@@ -12,11 +13,13 @@ interface insecure {
     /// There are no requirements on the values of the returned bytes, however
     /// implementations are encouraged to return evenly distributed values with
     /// a long period.
+    @since(version = 0.2.0)
     get-insecure-random-bytes: func(len: u64) -> list<u8>;
 
     /// Return an insecure pseudo-random `u64` value.
     ///
     /// This function returns the same type of pseudo-random data as
     /// `get-insecure-random-bytes`, represented as a `u64`.
+    @since(version = 0.2.0)
     get-insecure-random-u64: func() -> u64;
 }

--- a/bin/wit/deps/random/random.wit
+++ b/bin/wit/deps/random/random.wit
@@ -1,8 +1,9 @@
-package wasi:random@0.2.0;
+package wasi:random@0.2.3;
 /// WASI Random is a random data API.
 ///
 /// It is intended to be portable at least between Unix-family platforms and
 /// Windows.
+@since(version = 0.2.0)
 interface random {
     /// Return `len` cryptographically-secure random or pseudo-random bytes.
     ///
@@ -16,11 +17,13 @@ interface random {
     /// This function must always return fresh data. Deterministic environments
     /// must omit this function, rather than implementing it with deterministic
     /// data.
+    @since(version = 0.2.0)
     get-random-bytes: func(len: u64) -> list<u8>;
 
     /// Return a cryptographically-secure random or pseudo-random `u64` value.
     ///
     /// This function returns the same type of data as `get-random-bytes`,
     /// represented as a `u64`.
+    @since(version = 0.2.0)
     get-random-u64: func() -> u64;
 }

--- a/bin/wit/deps/random/world.wit
+++ b/bin/wit/deps/random/world.wit
@@ -1,7 +1,13 @@
-package wasi:random@0.2.0;
+package wasi:random@0.2.3;
 
+@since(version = 0.2.0)
 world imports {
+    @since(version = 0.2.0)
     import random;
+
+    @since(version = 0.2.0)
     import insecure;
+
+    @since(version = 0.2.0)
     import insecure-seed;
 }

--- a/bin/wit/deps/sockets/instance-network.wit
+++ b/bin/wit/deps/sockets/instance-network.wit
@@ -1,9 +1,11 @@
 
 /// This interface provides a value-export of the default network handle..
+@since(version = 0.2.0)
 interface instance-network {
+    @since(version = 0.2.0)
     use network.{network};
 
     /// Get a handle to the default network.
+    @since(version = 0.2.0)
     instance-network: func() -> network;
-
 }

--- a/bin/wit/deps/sockets/ip-name-lookup.wit
+++ b/bin/wit/deps/sockets/ip-name-lookup.wit
@@ -1,8 +1,9 @@
-
+@since(version = 0.2.0)
 interface ip-name-lookup {
-    use wasi:io/poll@0.2.0.{pollable};
+    @since(version = 0.2.0)
+    use wasi:io/poll@0.2.3.{pollable};
+    @since(version = 0.2.0)
     use network.{network, error-code, ip-address};
-
 
     /// Resolve an internet host name to a list of IP addresses.
     ///
@@ -24,8 +25,10 @@ interface ip-name-lookup {
     /// - <https://man7.org/linux/man-pages/man3/getaddrinfo.3.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=getaddrinfo&sektion=3>
+    @since(version = 0.2.0)
     resolve-addresses: func(network: borrow<network>, name: string) -> result<resolve-address-stream, error-code>;
 
+    @since(version = 0.2.0)
     resource resolve-address-stream {
         /// Returns the next address from the resolver.
         ///
@@ -40,12 +43,14 @@ interface ip-name-lookup {
         /// - `temporary-resolver-failure`: A temporary failure in name resolution occurred. (EAI_AGAIN)
         /// - `permanent-resolver-failure`: A permanent failure in name resolution occurred. (EAI_FAIL)
         /// - `would-block`:                A result is not available yet. (EWOULDBLOCK, EAGAIN)
+        @since(version = 0.2.0)
         resolve-next-address: func() -> result<option<ip-address>, error-code>;
 
         /// Create a `pollable` which will resolve once the stream is ready for I/O.
         ///
-        /// Note: this function is here for WASI Preview2 only.
+        /// Note: this function is here for WASI 0.2 only.
         /// It's planned to be removed when `future` is natively supported in Preview3.
+        @since(version = 0.2.0)
         subscribe: func() -> pollable;
     }
 }

--- a/bin/wit/deps/sockets/network.wit
+++ b/bin/wit/deps/sockets/network.wit
@@ -1,8 +1,12 @@
-
+@since(version = 0.2.0)
 interface network {
+    @unstable(feature = network-error-code)
+    use wasi:io/error@0.2.3.{error};
+
     /// An opaque resource that represents access to (a subset of) the network.
     /// This enables context-based security for networking.
     /// There is no need for this to map 1:1 to a physical network interface.
+    @since(version = 0.2.0)
     resource network;
 
     /// Error codes.
@@ -17,6 +21,7 @@ interface network {
     /// - `concurrency-conflict`
     ///
     /// See each individual API for what the POSIX equivalents are. They sometimes differ per API.
+    @since(version = 0.2.0)
     enum error-code {
         /// Unknown error
         unknown,
@@ -103,6 +108,20 @@ interface network {
         permanent-resolver-failure,
     }
 
+    /// Attempts to extract a network-related `error-code` from the stream
+    /// `error` provided.
+    ///
+    /// Stream operations which return `stream-error::last-operation-failed`
+    /// have a payload with more information about the operation that failed.
+    /// This payload can be passed through to this function to see if there's
+    /// network-related information about the error to return.
+    ///
+    /// Note that this function is fallible because not all stream-related
+    /// errors are network-related errors.
+    @unstable(feature = network-error-code)
+    network-error-code: func(err: borrow<error>) -> option<error-code>;
+
+    @since(version = 0.2.0)
     enum ip-address-family {
         /// Similar to `AF_INET` in POSIX.
         ipv4,
@@ -111,14 +130,18 @@ interface network {
         ipv6,
     }
 
+    @since(version = 0.2.0)
     type ipv4-address = tuple<u8, u8, u8, u8>;
+    @since(version = 0.2.0)
     type ipv6-address = tuple<u16, u16, u16, u16, u16, u16, u16, u16>;
 
+    @since(version = 0.2.0)
     variant ip-address {
         ipv4(ipv4-address),
         ipv6(ipv6-address),
     }
 
+    @since(version = 0.2.0)
     record ipv4-socket-address {
         /// sin_port
         port: u16,
@@ -126,6 +149,7 @@ interface network {
         address: ipv4-address,
     }
 
+    @since(version = 0.2.0)
     record ipv6-socket-address {
         /// sin6_port
         port: u16,
@@ -137,9 +161,9 @@ interface network {
         scope-id: u32,
     }
 
+    @since(version = 0.2.0)
     variant ip-socket-address {
         ipv4(ipv4-socket-address),
         ipv6(ipv6-socket-address),
     }
-
 }

--- a/bin/wit/deps/sockets/tcp-create-socket.wit
+++ b/bin/wit/deps/sockets/tcp-create-socket.wit
@@ -1,6 +1,8 @@
-
+@since(version = 0.2.0)
 interface tcp-create-socket {
+    @since(version = 0.2.0)
     use network.{network, error-code, ip-address-family};
+    @since(version = 0.2.0)
     use tcp.{tcp-socket};
 
     /// Create a new TCP socket.
@@ -23,5 +25,6 @@ interface tcp-create-socket {
     /// - <https://man7.org/linux/man-pages/man2/socket.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
+    @since(version = 0.2.0)
     create-tcp-socket: func(address-family: ip-address-family) -> result<tcp-socket, error-code>;
 }

--- a/bin/wit/deps/sockets/tcp.wit
+++ b/bin/wit/deps/sockets/tcp.wit
@@ -1,10 +1,15 @@
-
+@since(version = 0.2.0)
 interface tcp {
-    use wasi:io/streams@0.2.0.{input-stream, output-stream};
-    use wasi:io/poll@0.2.0.{pollable};
-    use wasi:clocks/monotonic-clock@0.2.0.{duration};
+    @since(version = 0.2.0)
+    use wasi:io/streams@0.2.3.{input-stream, output-stream};
+    @since(version = 0.2.0)
+    use wasi:io/poll@0.2.3.{pollable};
+    @since(version = 0.2.0)
+    use wasi:clocks/monotonic-clock@0.2.3.{duration};
+    @since(version = 0.2.0)
     use network.{network, error-code, ip-socket-address, ip-address-family};
 
+    @since(version = 0.2.0)
     enum shutdown-type {
         /// Similar to `SHUT_RD` in POSIX.
         receive,
@@ -27,8 +32,8 @@ interface tcp {
     /// - `connect-in-progress`
     /// - `connected`
     /// - `closed`
-    /// See <https://github.com/WebAssembly/wasi-sockets/TcpSocketOperationalSemantics.md>
-    /// for a more information.
+    /// See <https://github.com/WebAssembly/wasi-sockets/blob/main/TcpSocketOperationalSemantics.md>
+    /// for more information.
     ///
     /// Note: Except where explicitly mentioned, whenever this documentation uses
     /// the term "bound" without backticks it actually means: in the `bound` state *or higher*.
@@ -37,6 +42,7 @@ interface tcp {
     /// In addition to the general error codes documented on the
     /// `network::error-code` type, TCP socket methods may always return
     /// `error(invalid-state)` when in the `closed` state.
+    @since(version = 0.2.0)
     resource tcp-socket {
         /// Bind the socket to a specific network on the provided IP address and port.
         ///
@@ -76,13 +82,15 @@ interface tcp {
         /// - <https://man7.org/linux/man-pages/man2/bind.2.html>
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
+        @since(version = 0.2.0)
         start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>;
+        @since(version = 0.2.0)
         finish-bind: func() -> result<_, error-code>;
 
         /// Connect to a remote endpoint.
         ///
         /// On success:
-        /// - the socket is transitioned into the `connection` state.
+        /// - the socket is transitioned into the `connected` state.
         /// - a pair of streams is returned that can be used to read & write to the connection
         ///
         /// After a failed connection attempt, the socket will be in the `closed`
@@ -121,7 +129,9 @@ interface tcp {
         /// - <https://man7.org/linux/man-pages/man2/connect.2.html>
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
         /// - <https://man.freebsd.org/cgi/man.cgi?connect>
+        @since(version = 0.2.0)
         start-connect: func(network: borrow<network>, remote-address: ip-socket-address) -> result<_, error-code>;
+        @since(version = 0.2.0)
         finish-connect: func() -> result<tuple<input-stream, output-stream>, error-code>;
 
         /// Start listening for new connections.
@@ -149,7 +159,9 @@ interface tcp {
         /// - <https://man7.org/linux/man-pages/man2/listen.2.html>
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
+        @since(version = 0.2.0)
         start-listen: func() -> result<_, error-code>;
+        @since(version = 0.2.0)
         finish-listen: func() -> result<_, error-code>;
 
         /// Accept a new client socket.
@@ -178,6 +190,7 @@ interface tcp {
         /// - <https://man7.org/linux/man-pages/man2/accept.2.html>
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
+        @since(version = 0.2.0)
         accept: func() -> result<tuple<tcp-socket, input-stream, output-stream>, error-code>;
 
         /// Get the bound local address.
@@ -196,6 +209,7 @@ interface tcp {
         /// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
         /// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
+        @since(version = 0.2.0)
         local-address: func() -> result<ip-socket-address, error-code>;
 
         /// Get the remote address.
@@ -208,16 +222,19 @@ interface tcp {
         /// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
+        @since(version = 0.2.0)
         remote-address: func() -> result<ip-socket-address, error-code>;
 
         /// Whether the socket is in the `listening` state.
         ///
         /// Equivalent to the SO_ACCEPTCONN socket option.
+        @since(version = 0.2.0)
         is-listening: func() -> bool;
 
         /// Whether this is a IPv4 or IPv6 socket.
         ///
         /// Equivalent to the SO_DOMAIN socket option.
+        @since(version = 0.2.0)
         address-family: func() -> ip-address-family;
 
         /// Hints the desired listen queue size. Implementations are free to ignore this.
@@ -229,6 +246,7 @@ interface tcp {
         /// - `not-supported`:        (set) The platform does not support changing the backlog size after the initial listen.
         /// - `invalid-argument`:     (set) The provided value was 0.
         /// - `invalid-state`:        (set) The socket is in the `connect-in-progress` or `connected` state.
+        @since(version = 0.2.0)
         set-listen-backlog-size: func(value: u64) -> result<_, error-code>;
 
         /// Enables or disables keepalive.
@@ -240,7 +258,9 @@ interface tcp {
         /// These properties can be configured while `keep-alive-enabled` is false, but only come into effect when `keep-alive-enabled` is true.
         ///
         /// Equivalent to the SO_KEEPALIVE socket option.
+        @since(version = 0.2.0)
         keep-alive-enabled: func() -> result<bool, error-code>;
+        @since(version = 0.2.0)
         set-keep-alive-enabled: func(value: bool) -> result<_, error-code>;
 
         /// Amount of time the connection has to be idle before TCP starts sending keepalive packets.
@@ -253,7 +273,9 @@ interface tcp {
         ///
         /// # Typical errors
         /// - `invalid-argument`:     (set) The provided value was 0.
+        @since(version = 0.2.0)
         keep-alive-idle-time: func() -> result<duration, error-code>;
+        @since(version = 0.2.0)
         set-keep-alive-idle-time: func(value: duration) -> result<_, error-code>;
 
         /// The time between keepalive packets.
@@ -266,7 +288,9 @@ interface tcp {
         ///
         /// # Typical errors
         /// - `invalid-argument`:     (set) The provided value was 0.
+        @since(version = 0.2.0)
         keep-alive-interval: func() -> result<duration, error-code>;
+        @since(version = 0.2.0)
         set-keep-alive-interval: func(value: duration) -> result<_, error-code>;
 
         /// The maximum amount of keepalive packets TCP should send before aborting the connection.
@@ -279,7 +303,9 @@ interface tcp {
         ///
         /// # Typical errors
         /// - `invalid-argument`:     (set) The provided value was 0.
+        @since(version = 0.2.0)
         keep-alive-count: func() -> result<u32, error-code>;
+        @since(version = 0.2.0)
         set-keep-alive-count: func(value: u32) -> result<_, error-code>;
 
         /// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
@@ -288,7 +314,9 @@ interface tcp {
         ///
         /// # Typical errors
         /// - `invalid-argument`:     (set) The TTL value must be 1 or higher.
+        @since(version = 0.2.0)
         hop-limit: func() -> result<u8, error-code>;
+        @since(version = 0.2.0)
         set-hop-limit: func(value: u8) -> result<_, error-code>;
 
         /// The kernel buffer space reserved for sends/receives on this socket.
@@ -301,9 +329,13 @@ interface tcp {
         ///
         /// # Typical errors
         /// - `invalid-argument`:     (set) The provided value was 0.
+        @since(version = 0.2.0)
         receive-buffer-size: func() -> result<u64, error-code>;
+        @since(version = 0.2.0)
         set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
+        @since(version = 0.2.0)
         send-buffer-size: func() -> result<u64, error-code>;
+        @since(version = 0.2.0)
         set-send-buffer-size: func(value: u64) -> result<_, error-code>;
 
         /// Create a `pollable` which can be used to poll for, or block on,
@@ -318,11 +350,12 @@ interface tcp {
         /// `subscribe` only has to be called once per socket and can then be
         /// (re)used for the remainder of the socket's lifetime.
         ///
-        /// See <https://github.com/WebAssembly/wasi-sockets/TcpSocketOperationalSemantics.md#Pollable-readiness>
-        /// for a more information.
+        /// See <https://github.com/WebAssembly/wasi-sockets/blob/main/TcpSocketOperationalSemantics.md#pollable-readiness>
+        /// for more information.
         ///
-        /// Note: this function is here for WASI Preview2 only.
+        /// Note: this function is here for WASI 0.2 only.
         /// It's planned to be removed when `future` is natively supported in Preview3.
+        @since(version = 0.2.0)
         subscribe: func() -> pollable;
 
         /// Initiate a graceful shutdown.
@@ -335,7 +368,7 @@ interface tcp {
         ///   associated with this socket will be closed and a FIN packet will be sent.
         /// - `both`: Same effect as `receive` & `send` combined.
         ///
-        /// This function is idempotent. Shutting a down a direction more than once
+        /// This function is idempotent; shutting down a direction more than once
         /// has no effect and returns `ok`.
         ///
         /// The shutdown function does not close (drop) the socket.
@@ -348,6 +381,7 @@ interface tcp {
         /// - <https://man7.org/linux/man-pages/man2/shutdown.2.html>
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=shutdown&sektion=2>
+        @since(version = 0.2.0)
         shutdown: func(shutdown-type: shutdown-type) -> result<_, error-code>;
     }
 }

--- a/bin/wit/deps/sockets/udp-create-socket.wit
+++ b/bin/wit/deps/sockets/udp-create-socket.wit
@@ -1,6 +1,8 @@
-
+@since(version = 0.2.0)
 interface udp-create-socket {
+    @since(version = 0.2.0)
     use network.{network, error-code, ip-address-family};
+    @since(version = 0.2.0)
     use udp.{udp-socket};
 
     /// Create a new UDP socket.
@@ -23,5 +25,6 @@ interface udp-create-socket {
     /// - <https://man7.org/linux/man-pages/man2/socket.2.html>
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
+    @since(version = 0.2.0)
     create-udp-socket: func(address-family: ip-address-family) -> result<udp-socket, error-code>;
 }

--- a/bin/wit/deps/sockets/udp.wit
+++ b/bin/wit/deps/sockets/udp.wit
@@ -1,9 +1,12 @@
-
+@since(version = 0.2.0)
 interface udp {
-    use wasi:io/poll@0.2.0.{pollable};
+    @since(version = 0.2.0)
+    use wasi:io/poll@0.2.3.{pollable};
+    @since(version = 0.2.0)
     use network.{network, error-code, ip-socket-address, ip-address-family};
 
     /// A received datagram.
+    @since(version = 0.2.0)
     record incoming-datagram {
         /// The payload.
         /// 
@@ -19,6 +22,7 @@ interface udp {
     }
 
     /// A datagram to be sent out.
+    @since(version = 0.2.0)
     record outgoing-datagram {
         /// The payload.
         data: list<u8>,
@@ -33,9 +37,8 @@ interface udp {
         remote-address: option<ip-socket-address>,
     }
 
-
-
     /// A UDP socket handle.
+    @since(version = 0.2.0)
     resource udp-socket {
         /// Bind the socket to a specific network on the provided IP address and port.
         ///
@@ -63,7 +66,9 @@ interface udp {
         /// - <https://man7.org/linux/man-pages/man2/bind.2.html>
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
+        @since(version = 0.2.0)
         start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>;
+        @since(version = 0.2.0)
         finish-bind: func() -> result<_, error-code>;
 
         /// Set up inbound & outbound communication channels, optionally to a specific peer.
@@ -106,6 +111,7 @@ interface udp {
         /// - <https://man7.org/linux/man-pages/man2/connect.2.html>
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
         /// - <https://man.freebsd.org/cgi/man.cgi?connect>
+        @since(version = 0.2.0)
         %stream: func(remote-address: option<ip-socket-address>) -> result<tuple<incoming-datagram-stream, outgoing-datagram-stream>, error-code>;
 
         /// Get the current bound address.
@@ -124,6 +130,7 @@ interface udp {
         /// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
         /// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
+        @since(version = 0.2.0)
         local-address: func() -> result<ip-socket-address, error-code>;
 
         /// Get the address the socket is currently streaming to.
@@ -136,11 +143,13 @@ interface udp {
         /// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
+        @since(version = 0.2.0)
         remote-address: func() -> result<ip-socket-address, error-code>;
 
         /// Whether this is a IPv4 or IPv6 socket.
         ///
         /// Equivalent to the SO_DOMAIN socket option.
+        @since(version = 0.2.0)
         address-family: func() -> ip-address-family;
 
         /// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
@@ -149,7 +158,9 @@ interface udp {
         ///
         /// # Typical errors
         /// - `invalid-argument`:     (set) The TTL value must be 1 or higher.
+        @since(version = 0.2.0)
         unicast-hop-limit: func() -> result<u8, error-code>;
+        @since(version = 0.2.0)
         set-unicast-hop-limit: func(value: u8) -> result<_, error-code>;
 
         /// The kernel buffer space reserved for sends/receives on this socket.
@@ -162,18 +173,24 @@ interface udp {
         ///
         /// # Typical errors
         /// - `invalid-argument`:     (set) The provided value was 0.
+        @since(version = 0.2.0)
         receive-buffer-size: func() -> result<u64, error-code>;
+        @since(version = 0.2.0)
         set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
+        @since(version = 0.2.0)
         send-buffer-size: func() -> result<u64, error-code>;
+        @since(version = 0.2.0)
         set-send-buffer-size: func(value: u64) -> result<_, error-code>;
 
         /// Create a `pollable` which will resolve once the socket is ready for I/O.
         ///
-        /// Note: this function is here for WASI Preview2 only.
+        /// Note: this function is here for WASI 0.2 only.
         /// It's planned to be removed when `future` is natively supported in Preview3.
+        @since(version = 0.2.0)
         subscribe: func() -> pollable;
     }
 
+    @since(version = 0.2.0)
     resource incoming-datagram-stream {
         /// Receive messages on the socket.
         ///
@@ -198,15 +215,18 @@ interface udp {
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom>
         /// - <https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms741687(v=vs.85)>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=recv&sektion=2>
+        @since(version = 0.2.0)
         receive: func(max-results: u64) -> result<list<incoming-datagram>, error-code>;
 
         /// Create a `pollable` which will resolve once the stream is ready to receive again.
         ///
-        /// Note: this function is here for WASI Preview2 only.
+        /// Note: this function is here for WASI 0.2 only.
         /// It's planned to be removed when `future` is natively supported in Preview3.
+        @since(version = 0.2.0)
         subscribe: func() -> pollable;
     }
 
+    @since(version = 0.2.0)
     resource outgoing-datagram-stream {
         /// Check readiness for sending. This function never blocks.
         ///
@@ -255,12 +275,14 @@ interface udp {
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto>
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasendmsg>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=send&sektion=2>
+        @since(version = 0.2.0)
         send: func(datagrams: list<outgoing-datagram>) -> result<u64, error-code>;
         
         /// Create a `pollable` which will resolve once the stream is ready to send again.
         ///
-        /// Note: this function is here for WASI Preview2 only.
+        /// Note: this function is here for WASI 0.2 only.
         /// It's planned to be removed when `future` is natively supported in Preview3.
+        @since(version = 0.2.0)
         subscribe: func() -> pollable;
     }
 }

--- a/bin/wit/deps/sockets/world.wit
+++ b/bin/wit/deps/sockets/world.wit
@@ -1,11 +1,19 @@
-package wasi:sockets@0.2.0;
+package wasi:sockets@0.2.3;
 
+@since(version = 0.2.0)
 world imports {
+    @since(version = 0.2.0)
     import instance-network;
+    @since(version = 0.2.0)
     import network;
+    @since(version = 0.2.0)
     import udp;
+    @since(version = 0.2.0)
     import udp-create-socket;
+    @since(version = 0.2.0)
     import tcp;
+    @since(version = 0.2.0)
     import tcp-create-socket;
+    @since(version = 0.2.0)
     import ip-name-lookup;
 }

--- a/bin/wit/deps/spin@2.0.0/spin.wit
+++ b/bin/wit/deps/spin@2.0.0/spin.wit
@@ -1,7 +1,7 @@
 package fermyon:spin@2.0.0;
 
 world spin-imports {
-  import wasi:http/outgoing-handler@0.2.0;
+  import wasi:http/outgoing-handler@0.2.3;
   import llm;
   import redis;
   import postgres;
@@ -19,7 +19,7 @@ world spin-redis {
 
 world spin-http {
   include spin-imports;
-  export wasi:http/incoming-handler@0.2.0;
+  export wasi:http/incoming-handler@0.2.3;
 }
 
 world spin-all {

--- a/bin/wit/world.wit
+++ b/bin/wit/world.wit
@@ -14,7 +14,7 @@ world spin3-redis {
 
 world spin3-http {
   include spin3-imports;
-  export wasi:http/incoming-handler@0.2.0;
+  export wasi:http/incoming-handler@0.2.3;
 }
 
 world spin3-all {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@fermyon/spin-sdk",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fermyon/spin-sdk",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@bytecodealliance/componentize-js": "^0.13.1",
+        "@bytecodealliance/componentize-js": "^0.16.0",
         "@fermyon/knitwit": "^0.3.0",
         "itty-router": "^3.0.12",
         "typedoc-plugin-missing-exports": "^3.0.0",
@@ -26,29 +26,29 @@
       }
     },
     "node_modules/@bytecodealliance/componentize-js": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@bytecodealliance/componentize-js/-/componentize-js-0.13.1.tgz",
-      "integrity": "sha512-a5kq/iXIgnW0Tws3m/nm9xb7CtcT4jllhmzUDZua3/LGs4ZWGoQQwxfqTHB/r7cL6aXhy0wUoiTNvVJ8sLPzbw==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/componentize-js/-/componentize-js-0.16.0.tgz",
+      "integrity": "sha512-x5vKTLd4I+ovC58l4zjld+XTJSve5Glblu7Ola/2v6vOh0YS2eODihDVLWkl4kd9GC/8OjxwEdE0pXelQt6ovw==",
       "workspaces": [
         "."
       ],
       "dependencies": {
-        "@bytecodealliance/jco": "^1.7.0",
-        "@bytecodealliance/weval": "^0.3.2",
+        "@bytecodealliance/jco": "^1.9.1",
+        "@bytecodealliance/weval": "^0.3.3",
         "@bytecodealliance/wizer": "^7.0.5",
         "es-module-lexer": "^1.5.4"
       }
     },
     "node_modules/@bytecodealliance/jco": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-1.8.1.tgz",
-      "integrity": "sha512-mYjE7lrSWEzFD6lAVA4skm9/6DvorFjuO5DHoxzwWlJ2hKyO/d9t0Wx1V0nT5L1s7+98ZtVSB1emYLNMebpMdA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-1.9.1.tgz",
+      "integrity": "sha512-Xmd1iw2OrWhlLOPZraFTBuE1AGfMSQVqKzswmq3k1vQ5B0EJe8O1CFG/UJeRXwbq1fxHHS9DTtlfAZiTeOdLWQ==",
       "license": "(Apache-2.0 WITH LLVM-exception)",
       "workspaces": [
         "packages/preview2-shim"
       ],
       "dependencies": {
-        "@bytecodealliance/componentize-js": "^0.14.0",
+        "@bytecodealliance/componentize-js": "^0.15.0",
         "@bytecodealliance/preview2-shim": "^0.17.1",
         "binaryen": "^120.0.0",
         "chalk-template": "^1",
@@ -62,15 +62,15 @@
       }
     },
     "node_modules/@bytecodealliance/jco/node_modules/@bytecodealliance/componentize-js": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@bytecodealliance/componentize-js/-/componentize-js-0.14.0.tgz",
-      "integrity": "sha512-Y53lxcHEQz5k4PwqBY3+q6Y+TmFSu5mWhd+2dyURE7mk0GDaFYKRDoATCoXxD8Dvq/HgNPrDSE2X7AJIjPMtYQ==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/componentize-js/-/componentize-js-0.15.1.tgz",
+      "integrity": "sha512-bTQT+uwWNeyFXRiV6cp+5ERUKC2g6lyiMoeMys2/yg8IcWPwq+3btV1Pj/q0ueAwyiIsuQ//c+peMHPrNTmHOg==",
       "workspaces": [
         "."
       ],
       "dependencies": {
-        "@bytecodealliance/jco": "^1.7.1",
-        "@bytecodealliance/weval": "^0.3.2",
+        "@bytecodealliance/jco": "^1.8.1",
+        "@bytecodealliance/weval": "^0.3.3",
         "@bytecodealliance/wizer": "^7.0.5",
         "es-module-lexer": "^1.5.4"
       }
@@ -244,9 +244,9 @@
       }
     },
     "node_modules/@fermyon/knitwit": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@fermyon/knitwit/-/knitwit-0.3.0.tgz",
-      "integrity": "sha512-VW5Ew5vO5lhHg1p69yFa5Wa/4hijdTdkrAx378kgtZjTvz3AzJau4ge87YY6Fjd0XwFed4VPDH0nm50CQ4+ceQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@fermyon/knitwit/-/knitwit-0.3.1.tgz",
+      "integrity": "sha512-ejkxoZsIVuv2778omOQcn5MuB5GF1IovY5Xws8qDDx87vaisUVaqblxUVxIKdUbbVByxprblburoaFcvhVCCzw==",
       "license": "ISC",
       "dependencies": {
         "@bytecodealliance/preview2-shim": "^0.16.4",
@@ -1733,9 +1733,9 @@
       }
     },
     "node_modules/oniguruma-to-es": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-2.2.0.tgz",
-      "integrity": "sha512-EEsso27ri0sf+t4uRFEj5C5gvXQj0d0w1Y2qq06b+hDLBnvzO1rWTwEW4C7ytan6nhg4WPwE26eLoiPhHUbvKg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-2.3.0.tgz",
+      "integrity": "sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==",
       "license": "MIT",
       "dependencies": {
         "emoji-regex-xs": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fermyon/spin-sdk",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -25,7 +25,7 @@
     "typescript": "^5.4.3"
   },
   "dependencies": {
-    "@bytecodealliance/componentize-js": "^0.13.1",
+    "@bytecodealliance/componentize-js": "^0.16.0",
     "itty-router": "^3.0.12",
     "yargs": "^17.7.2",
     "typedoc-plugin-missing-exports": "^3.0.0",


### PR DESCRIPTION
This PR bumps ComponentizeJS which required us to update the `wit` files. This update also bring in a ton of new stuff like an updated StarlingMonkey engineer that supports blobs and formdata and also bug fixes which enable the use of AWS SDK again.

The build script is also updated to take into consideration the ComponentizeJs version that was used to build now.