### PR TITLE
Disable webpack performance hints

### DIFF
--- a/templates/http-js/content/webpack.config.js
+++ b/templates/http-js/content/webpack.config.js
@@ -20,4 +20,7 @@ module.exports = {
     optimization: {
         minimize: false
     },
+    performance: {
+        hints: false,
+    }
 };

--- a/templates/http-ts/content/webpack.config.js
+++ b/templates/http-ts/content/webpack.config.js
@@ -32,4 +32,7 @@ module.exports = {
     optimization: {
         minimize: false
     },
+    performance: {
+        hints: false,
+    }
 };

--- a/templates/redis-js/content/webpack.config.js
+++ b/templates/redis-js/content/webpack.config.js
@@ -20,4 +20,7 @@ module.exports = {
     optimization: {
         minimize: false
     },
+    performance: {
+        hints: false,
+    }
 };

--- a/templates/redis-ts/content/webpack.config.js
+++ b/templates/redis-ts/content/webpack.config.js
@@ -32,4 +32,7 @@ module.exports = {
     optimization: {
         minimize: false
     },
+    performance: {
+        hints: false,
+    }
 };


### PR DESCRIPTION
This PR disables webpack performance hints, to streamline `stdout` as part of `spin build`