### PR TITLE
add action to automate publish releases to npm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,18 @@ jobs:
           node-version: 22
           registry-url: 'https://registry.npmjs.org/'
 
+      - name: Verify tag matches package version
+        run: |
+          PACKAGE_VERSION=$(jq -r .version package.json)
+          TAG_VERSION=${{ github.ref_name }}
+          # Remove 'v' prefix from the tag if it exists
+          TAG_VERSION=${TAG_VERSION#v}
+
+          if [[ "$PACKAGE_VERSION" != "$TAG_VERSION" ]]; then
+            echo "Error: Git tag ($TAG_VERSION) does not match package.json version ($PACKAGE_VERSION)"
+            exit 1
+          fi   
+
       - name: Install dependencies
         run: npm ci
 
@@ -46,6 +58,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          RELEASE_TAG=$(npm view . version)
+          RELEASE_TAG=$(jq -r .version package.json)
           RELEASE_URL="https://www.npmjs.com/package/$(jq -r .name package.json)/v/$RELEASE_TAG"
           gh release create "v$RELEASE_TAG" --title "Release v$RELEASE_TAG" --notes "Published on npm: $RELEASE_URL"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,51 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - "v*" 
+
+# Serialize workflow runs. Not strictly necessary, but to be on the safer side.
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build the project
+        run: npm run build
+
+        # Determine if the tag is a release candidate or not
+      - name: Determine npm tag
+        id: npm_tag
+        run: |
+          if [[ "${{ github.ref_name }}" == *rc* ]]; then
+            echo "tag=next" >> $GITHUB_ENV
+          else
+            echo "tag=latest" >> $GITHUB_ENV
+            
+      - name: Publish to npm
+        run: npm publish --access=public --tag ${{ env.tag }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_TAG=$(npm view . version)
+          RELEASE_URL="https://www.npmjs.com/package/$(jq -r .name package.json)/v/$RELEASE_TAG"
+          gh release create "v$RELEASE_TAG" --title "Release v$RELEASE_TAG" --notes "Published on npm: $RELEASE_URL"


### PR DESCRIPTION
Adds action that publishes package to npm when a tag starting with `v` is pushed.