### PR TITLE
Support custom StarlingMonkey runtime builds

### DIFF
--- a/bin/j2w.mjs
+++ b/bin/j2w.mjs
@@ -23,6 +23,10 @@ const args = yargs(hideBin(process.argv))
         alias: 'd',
         describe: 'Path to wit file or folder',
     })
+    .option('runtime-path', {
+        alias: 'r',
+        describe: 'Path to a custom runtime wasm file',
+    })
     .option('output', {
         alias: 'o',
         describe: 'Path to the output file',
@@ -115,6 +119,7 @@ async function saveBuildData(buildDataPath, checksum, version) {
         const { component } = await componentize(precompiledSource, {
             sourceName: basename(src),
             witPath,
+            engine: args.runtimePath,
             worldName: args.triggerType,
             disableFeatures: [],
             enableFeatures: ["http"],

--- a/test/test.sh
+++ b/test/test.sh
@@ -18,6 +18,7 @@ echo "built the test app successfully"
 # Start the spin app in the background
 echo "Starting Spin app"
 spin up &
+SPIN_PID=$!
 
 # wait for app to be up and running
 echo "Waiting for Spin app to be ready"
@@ -30,7 +31,7 @@ echo "\n\nTest completed"
 
 # kill the spin app
 echo "Stopping Spin"
-killall spin
+kill -9 $SPIN_PID
 
 
 if [ "$isFailed" = true ] ; then


### PR DESCRIPTION
ComponentizeJS already supports them, so this just adds an option to `j2w.js`.