### PR TITLE
Fetch event listener should not be async

### DIFF
--- a/templates/http-js/content/src/index.js
+++ b/templates/http-js/content/src/index.js
@@ -10,6 +10,6 @@ router
     .get("/", () => new Response("hello universe"))
     .get('/hello/:name', ({ name }) => `Hello, ${name}!`)
 
-addEventListener('fetch', async (event) => {
+addEventListener('fetch', (event) => {
     event.respondWith(router.fetch(event.request));
 });

--- a/templates/http-ts/content/src/index.ts
+++ b/templates/http-ts/content/src/index.ts
@@ -11,6 +11,6 @@ router
     .get('/hello/:name', ({ name }) => `Hello, ${name}!`)
 
 //@ts-ignore
-addEventListener('fetch', async (event: FetchEvent) => {
+addEventListener('fetch', (event: FetchEvent) => {
     event.respondWith(router.fetch(event.request));
 });


### PR DESCRIPTION
Because it sets the user up for subtle bugs and we bar subtle bugs.
