### PR TITLE
Fix TypeScript complaining about duplicate functions

### DIFF
--- a/templates/http-ts/content/tsconfig.json
+++ b/templates/http-ts/content/tsconfig.json
@@ -14,5 +14,8 @@
         "strict": true,
         "noImplicitReturns": true,
         "moduleResolution": "node"
-    }
+    },
+    "include": [
+        "src/**/*"
+    ]
 }

--- a/templates/redis-ts/content/tsconfig.json
+++ b/templates/redis-ts/content/tsconfig.json
@@ -14,5 +14,8 @@
         "strict": true,
         "noImplicitReturns": true,
         "moduleResolution": "node"
-    }
+    },
+    "include": [
+        "src/**/*"
+    ]
 }


### PR DESCRIPTION
If you use the TypeScript template, and write a function instead of doing everything at top level, it compiles the first time, but then complains about "duplicate function" and refuses to recompile.  I believe this is the desired fix (I think we went through a few workarounds but this seems the betterest of them).
