### PR TITLE
update to componentizeJS 0.17

### DIFF
--- a/bin/j2w.mjs
+++ b/bin/j2w.mjs
@@ -37,9 +37,19 @@ const args = yargs(hideBin(process.argv))
         describe: "Spin trigger to target",
         demandOption: true
     })
+    .option('debug-build', {
+        describe: "Use debug build of the runtime",
+        type: 'boolean',
+    })
     .option('aot', {
         describe: "Enable Ahead of Time compilation",
         type: 'boolean',
+    })
+    .check((argv) => {
+        if (argv['debug-build'] && argv['runtime-path']) {
+            throw new Error("The --runtime-path option cannot be used when --debug-build is enabled.");
+        }
+        return true;
     })
     .argv;
 
@@ -123,6 +133,7 @@ async function saveBuildData(buildDataPath, checksum, version) {
             worldName: args.triggerType,
             disableFeatures: [],
             enableFeatures: ["http"],
+            debugBuild: args.debugBuild ?? false,
             enableAot: args.aot
         });
 

--- a/bin/wit/deps/spin@2.0.0/spin.wit
+++ b/bin/wit/deps/spin@2.0.0/spin.wit
@@ -1,6 +1,7 @@
 package fermyon:spin@2.0.0;
 
 world spin-imports {
+  import wasi:cli/environment@0.2.3;
   import wasi:http/outgoing-handler@0.2.3;
   import llm;
   import redis;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@fermyon/spin-sdk",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fermyon/spin-sdk",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@bytecodealliance/componentize-js": "^0.16.0",
+        "@bytecodealliance/componentize-js": "^0.17.0",
         "@fermyon/knitwit": "^0.3.0",
         "acorn-walk": "^8.3.4",
         "acron": "^1.0.5",
@@ -30,9 +30,9 @@
       }
     },
     "node_modules/@bytecodealliance/componentize-js": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@bytecodealliance/componentize-js/-/componentize-js-0.16.0.tgz",
-      "integrity": "sha512-x5vKTLd4I+ovC58l4zjld+XTJSve5Glblu7Ola/2v6vOh0YS2eODihDVLWkl4kd9GC/8OjxwEdE0pXelQt6ovw==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/componentize-js/-/componentize-js-0.17.0.tgz",
+      "integrity": "sha512-FDgO5UPipfjyq5OghSB4JW313LkQJK3Sl647WH1jvIuYAyCq1j+bMt+Q66c3UF6IVs6PneNTGfGSjYgzID/k0w==",
       "workspaces": [
         "."
       ],
@@ -40,7 +40,7 @@
         "@bytecodealliance/jco": "^1.9.1",
         "@bytecodealliance/weval": "^0.3.3",
         "@bytecodealliance/wizer": "^7.0.5",
-        "es-module-lexer": "^1.5.4"
+        "es-module-lexer": "^1.6.0"
       }
     },
     "node_modules/@bytecodealliance/jco": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fermyon/spin-sdk",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -26,7 +26,7 @@
     "typescript": "^5.4.3"
   },
   "dependencies": {
-    "@bytecodealliance/componentize-js": "^0.16.0",
+    "@bytecodealliance/componentize-js": "^0.17.0",
     "@fermyon/knitwit": "^0.3.0",
     "acorn-walk": "^8.3.4",
     "acron": "^1.0.5",

--- a/plugins/webpack/index.js
+++ b/plugins/webpack/index.js
@@ -1,28 +1,26 @@
 class SpinSdkPlugin {
     constructor() {
-        this.externals = {
-            "wasi:http/types@0.2.0": "wasi:http/types@0.2.0",
-            "wasi:cli/environment@0.2.0": "wasi:cli/environment@0.2.0",
-            "wasi:filesystem/preopens@0.2.0": "wasi:filesystem/preopens@0.2.0",
-            "fermyon:spin/llm@2.0.0": "fermyon:spin/llm@2.0.0",
-            "fermyon:spin/variables@2.0.0": "fermyon:spin/variables@2.0.0",
-            "fermyon:spin/redis@2.0.0": "fermyon:spin/redis@2.0.0",
-            "fermyon:spin/key-value@2.0.0": "fermyon:spin/key-value@2.0.0",
-            "fermyon:spin/sqlite@2.0.0": "fermyon:spin/sqlite@2.0.0",
-            "fermyon:spin/postgres@2.0.0": "fermyon:spin/postgres@2.0.0",
-            "fermyon:spin/mysql@2.0.0": "fermyon:spin/mysql@2.0.0",
-            "fermyon:spin/mqtt@2.0.0": "fermyon:spin/mqtt@2.0.0",
-            "wasi:config/store@0.2.0-draft-2024-09-27": "wasi:config/store@0.2.0-draft-2024-09-27",
-            "spin:postgres/postgres@3.0.0": "spin:postgres/postgres@3.0.0",
-        };
+        this.externals = [
+            /^wasi:.*/,
+            /^fermyon:.*/,
+            /^spin:.*/,
+        ];
     }
 
     apply(compiler) {
         // If externals are already defined, merge them with new externals
-        if (compiler.options.externals && typeof compiler.options.externals === 'object') {
-            this.externals = Object.assign({}, compiler.options.externals, this.externals);
+        const userExternals = compiler.options.externals;
+
+        if (Array.isArray(userExternals)) {
+            // Append to the existing array
+            compiler.options.externals = [...userExternals, ...this.externals];
+        } else if (typeof userExternals === 'object') {
+            // Wrap in an array and add the object as-is
+            compiler.options.externals = [userExternals, ...this.externals];
+        } else {
+            // Default: Just use our externals
+            compiler.options.externals = [...this.externals];
         }
-        compiler.options.externals = this.externals;
     }
 }
 

--- a/test/test-app/package-lock.json
+++ b/test/test-app/package-lock.json
@@ -7,7 +7,6 @@
         "": {
             "name": "test-app",
             "version": "1.0.0",
-            "hasInstallScript": true,
             "license": "ISC",
             "dependencies": {
                 "@fermyon/spin-sdk": "file:../../",
@@ -23,22 +22,26 @@
         },
         "../..": {
             "name": "@fermyon/spin-sdk",
-            "version": "3.0.0",
+            "version": "3.2.0",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@bytecodealliance/componentize-js": "^0.16.0",
+                "@bytecodealliance/componentize-js": "^0.17.0",
                 "@fermyon/knitwit": "^0.3.0",
-                "itty-router": "^5.0.18",
-                "typedoc-plugin-missing-exports": "^3.0.0",
+                "acorn-walk": "^8.3.4",
+                "acron": "^1.0.5",
+                "magic-string": "^0.30.17",
+                "regexpu-core": "^6.2.0",
                 "yargs": "^17.7.2"
             },
             "bin": {
                 "j2w": "bin/j2w.mjs"
             },
             "devDependencies": {
+                "@shipgirl/typedoc-plugin-versions": "^0.3.0",
                 "prettier": "^3.2.5",
-                "typedoc": "^0.26.4",
+                "typedoc": "^0.27.7",
+                "typedoc-plugin-missing-exports": "^3.1.0",
                 "typescript": "^5.4.3"
             }
         },

--- a/test/test-app/package.json
+++ b/test/test-app/package.json
@@ -4,9 +4,8 @@
     "description": "",
     "main": "index.js",
     "scripts": {
-        "build": "npx webpack --mode=production && npx mkdirp dist && npx j2w -i build/bundle.js -d build/wit/knitwit -n combined -o dist/test-app.wasm --aot",
-        "test": "echo \"Error: no test specified\" && exit 1",
-        "postinstall": "knitwit --out-dir build/wit/knitwit"
+        "build": "knitwit --out-dir build/wit/knitwit && npx webpack --mode=production && npx mkdirp dist && npx j2w --debug-build -i build/bundle.js -d build/wit/knitwit -n combined -o dist/test-app.wasm --aot",
+        "test": "echo \"Error: no test specified\" && exit 1"
     },
     "keywords": [],
     "author": "",


### PR DESCRIPTION
- Bumps ComponentizeJS version and exposes flag for debug builds.
- this PR also bumps the package version in preparation for the next release.