### PR TITLE
(packages/build-tools): Bump componentizeJS and fix windows paths

### DIFF
--- a/packages/build-tools/package-lock.json
+++ b/packages/build-tools/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0 WITH LLVM-exception",
       "dependencies": {
-        "@bytecodealliance/componentize-js": "^0.18.0",
+        "@bytecodealliance/componentize-js": "^0.18.1",
         "@bytecodealliance/jco": "^1.10.2",
         "yargs": "^17.7.2"
       },
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@bytecodealliance/componentize-js": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@bytecodealliance/componentize-js/-/componentize-js-0.18.0.tgz",
-      "integrity": "sha512-yQTbGUjkmWADDCgP4y5hH7im9u2oFRvIjm3QM7z0To9OmDclD9T13yjTnKffWOPkyjJsFS1D0EY3Se5fgYnqtw==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/componentize-js/-/componentize-js-0.18.1.tgz",
+      "integrity": "sha512-LqdJFvguwPKKGfIpl4PxGXomfaOKnK8GyqwaZMhpCkc594Wc7ak4nrcAbQNRdQooYrSody24zfEZ5uqYJD/Jeg==",
       "workspaces": [
         "."
       ],

--- a/packages/build-tools/package.json
+++ b/packages/build-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinframework/build-tools",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -29,7 +29,7 @@
     "typescript": "^5.7.3"
   },
   "dependencies": {
-    "@bytecodealliance/componentize-js": "^0.18.0",
+    "@bytecodealliance/componentize-js": "^0.18.1",
     "@bytecodealliance/jco": "^1.10.2",
     "yargs": "^17.7.2"
   },

--- a/packages/build-tools/src/wasiDepsParser.ts
+++ b/packages/build-tools/src/wasiDepsParser.ts
@@ -5,6 +5,7 @@ import { resolve } from 'node:path';
 import { platform } from 'node:process';
 const isWindows = platform === 'win32';
 
+// Copied from https://github.com/bytecodealliance/ComponentizeJS/blob/e5bb0da0c1ce1ee87eed45c970121ed5fe8cca3a/src/componentize.js#L26-L39
 function maybeWindowsPath(path: string): string {
   if (!path) return path;
   const resolvedPath = resolve(path);


### PR DESCRIPTION
This PR brings in fixes for windows paths when trying build with the tool. It converts the windows paths to ones that can be used in wasi. This PR also bumps the version of the package. 