### PR TITLE
Fix build caching

### DIFF
--- a/packages/build-tools/src/build.ts
+++ b/packages/build-tools/src/build.ts
@@ -1,5 +1,5 @@
 import {
-  calculateChecksum,
+  calculateFileChecksum,
   fileExists,
   getExistingBuildData,
 } from './utils.js';
@@ -9,15 +9,16 @@ export function getBuildDataPath(src: string): string {
 }
 
 export async function ShouldComponentize(
-src: string, outputPath: string, componentizeVersion: string, runtimeArgs: string,
+  src: string, outputPath: string, componentizeVersion: string, runtimeArgs: string, targetWitChecksum: string
 ) {
-  const sourceChecksum = await calculateChecksum(src);
+  const sourceChecksum = await calculateFileChecksum(src);
   const existingBuildData = await getExistingBuildData(getBuildDataPath(src));
 
   if (
     existingBuildData?.version == componentizeVersion &&
     existingBuildData?.checksum === sourceChecksum &&
     existingBuildData?.runtimeArgs === runtimeArgs &&
+    existingBuildData?.targetWitChecksum === targetWitChecksum &&
     (await fileExists(outputPath))
   ) {
     return false;

--- a/packages/build-tools/src/build.ts
+++ b/packages/build-tools/src/build.ts
@@ -1,5 +1,6 @@
+import { readFile } from 'node:fs/promises';
 import {
-  calculateFileChecksum,
+  calculateChecksum,
   fileExists,
   getExistingBuildData,
 } from './utils.js';
@@ -11,7 +12,7 @@ export function getBuildDataPath(src: string): string {
 export async function ShouldComponentize(
   src: string, outputPath: string, componentizeVersion: string, runtimeArgs: string, targetWitChecksum: string
 ) {
-  const sourceChecksum = await calculateFileChecksum(src);
+  const sourceChecksum = await calculateChecksum(await readFile(src));
   const existingBuildData = await getExistingBuildData(getBuildDataPath(src));
 
   if (

--- a/packages/build-tools/src/index.ts
+++ b/packages/build-tools/src/index.ts
@@ -4,8 +4,7 @@ import { componentize } from '@bytecodealliance/componentize-js';
 import { version as componentizeVersion } from '@bytecodealliance/componentize-js';
 import { getPackagesWithWasiDeps, processWasiDeps } from './wasiDepsParser.js';
 import {
-  calculateCheckSum,
-  calculateFileChecksum,
+  calculateChecksum,
   saveBuildData,
 } from './utils.js';
 import { getCliArgs } from './cli.js';
@@ -55,8 +54,7 @@ async function main() {
       'combined-wit:combined-wit@0.3.0',
     );
 
-    // Calcuilate the checksum of the inline wit
-    let inlineWitChecksum = await calculateCheckSum(inlineWit);
+    let inlineWitChecksum = await calculateChecksum(inlineWit);
     // Small optimization to skip componentization if the source file hasn't changed
     if (!(await ShouldComponentize(src, outputPath, componentizeVersion, runtimeArgs, inlineWitChecksum))) {
       console.log(
@@ -88,7 +86,7 @@ async function main() {
     // Save the checksum of the input file along with the componentize version
     await saveBuildData(
       getBuildDataPath(src),
-      await calculateFileChecksum(src),
+      await calculateChecksum(await readFile(src)),
       componentizeVersion,
       runtimeArgs,
       inlineWitChecksum,

--- a/packages/build-tools/src/utils.ts
+++ b/packages/build-tools/src/utils.ts
@@ -4,23 +4,17 @@ import { access, writeFile } from 'node:fs/promises';
 
 
 // Function to calculate file checksum
-export async function calculateFileChecksum(filePath: string) {
+export async function calculateChecksum(content: string | Buffer) {
   try {
-    const fileBuffer = await readFile(filePath);
     const hash = createHash('sha256');
-    hash.update(fileBuffer);
+    hash.update(content);
     return hash.digest('hex');
   } catch (error) {
-    console.error(`Error calculating checksum for file ${filePath}:`, error);
+    console.error(`Error calculating checksum:`, error);
     throw error;
   }
 }
 
-export function calculateCheckSum(data: string | Buffer): string {
-  const hash = createHash('sha256');
-  hash.update(data);
-  return hash.digest('hex');
-}
 
 // Function to check if a file exists
 export async function fileExists(filePath: string) {

--- a/packages/build-tools/src/utils.ts
+++ b/packages/build-tools/src/utils.ts
@@ -4,7 +4,7 @@ import { access, writeFile } from 'node:fs/promises';
 
 
 // Function to calculate file checksum
-export async function calculateChecksum(filePath: string) {
+export async function calculateFileChecksum(filePath: string) {
   try {
     const fileBuffer = await readFile(filePath);
     const hash = createHash('sha256');
@@ -14,6 +14,12 @@ export async function calculateChecksum(filePath: string) {
     console.error(`Error calculating checksum for file ${filePath}:`, error);
     throw error;
   }
+}
+
+export function calculateCheckSum(data: string | Buffer): string {
+  const hash = createHash('sha256');
+  hash.update(data);
+  return hash.digest('hex');
 }
 
 // Function to check if a file exists
@@ -43,13 +49,14 @@ export async function getExistingBuildData(buildDataPath: string) {
 }
 
 export async function saveBuildData(
-buildDataPath: string, checksum: string, version: string, runtimeArgs: string,
+  buildDataPath: string, checksum: string, version: string, runtimeArgs: string, targetWitChecksum: string
 ) {
   try {
     const checksumData = {
       version,
       checksum,
       runtimeArgs,
+      targetWitChecksum,
     };
     await writeFile(buildDataPath, JSON.stringify(checksumData, null, 2));
   } catch (error) {


### PR DESCRIPTION
Add a field to track the target world for which the build is done so that we re componentize when target world changes but the source does not.