### PR TITLE
fix handling of KV set and throw wrapped errors

### DIFF
--- a/packages/spin-kv/package-lock.json
+++ b/packages/spin-kv/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spinframework/spin-kv",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spinframework/spin-kv",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": " Apache-2.0 WITH LLVM-exception",
       "devDependencies": {
         "typescript": "^5.7.3"

--- a/packages/spin-kv/package.json
+++ b/packages/spin-kv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spinframework/spin-kv",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/spin-kv/tsconfig.json
+++ b/packages/spin-kv/tsconfig.json
@@ -1,12 +1,12 @@
 {
     "compilerOptions": {
         "target": "ES2020",
-        "module": "ES2020",
+        "module": "nodenext",
         "lib": [
             "ES2020",
             "WebWorker"
         ],
-        "moduleResolution": "node",
+        "moduleResolution": "nodenext",
         "declaration": true,
         "outDir": "dist",
         "strict": true,

--- a/test/test-app/src/index.ts
+++ b/test/test-app/src/index.ts
@@ -1,5 +1,5 @@
 import { AutoRouter } from "itty-router"
-import { headersTest, health, kvTest, kvTestUint8Array, outboundHttp, statusTest, stream, streamTest, testFunctionality } from "./test";
+import { headersTest, health, kvTest, kvTestArrayBuffer, kvTestUint8Array, outboundHttp, statusTest, stream, streamTest, testFunctionality } from "./test";
 
 let router = AutoRouter()
 
@@ -9,6 +9,7 @@ router.get("/statusTest", statusTest)
 router.get("/headersTest", headersTest)
 router.get("/outboundHttp", outboundHttp)
 router.get("/kvTest", kvTest)
+router.get("/kvTestArrayBuffer", kvTestArrayBuffer)
 router.get("/kvTestUint8Array", kvTestUint8Array)
 router.get("/streamTest", streamTest)
 router.get("/testFunctionality", testFunctionality)

--- a/test/test-app/src/test.ts
+++ b/test/test-app/src/test.ts
@@ -46,6 +46,18 @@ function kvTest(req: Request) {
     return new Response("failed", { status: 500 })
 }
 
+function kvTestArrayBuffer(req: Request) {
+    let store = Kv.openDefault()
+
+    let arr = new Uint8Array([1, 2, 3])
+    store.set("arr", arr.buffer)
+    let ret = store.get("arr")
+    if (ret == null || !isEqualBytes(new Uint8Array(ret), arr)) {
+        return new Response("failed", { status: 500 })
+    }
+    return new Response("success", { status: 200 })
+}
+
 function kvTestUint8Array(req: Request) {
     let store = Kv.openDefault()
 
@@ -87,6 +99,7 @@ async function testFunctionality(req: Request) {
         { name: "headersTest", validate: (resp: Response) => resp.status === 200 && resp.headers.get("Content-Type") === "text/html" },
         { name: "outboundHttp", validate: (resp: Response) => resp.status === 200 },
         { name: "kvTest", validate: (resp: Response) => resp.status === 200 },
+        { name: "kvTestArrayBuffer", validate: (resp: Response) => resp.status === 200 },
         { name: "kvTestUint8Array", validate: (resp: Response) => resp.status === 200 },
         { name: "streamTest", validate: (resp: Response) => resp.status === 200 },
     ];
@@ -112,6 +125,7 @@ export {
     statusTest,
     outboundHttp,
     kvTest,
+    kvTestArrayBuffer,
     kvTestUint8Array,
     streamTest
 }

--- a/test/test-app/tsconfig.json
+++ b/test/test-app/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "outDir": "./dist/",
         "noImplicitAny": true,
-        "module": "es6",
+        "module": "nodenext",
         "target": "es2020",
         "jsx": "react",
         "skipLibCheck": true,
@@ -13,6 +13,6 @@
         "allowJs": true,
         "strict": true,
         "noImplicitReturns": true,
-        "moduleResolution": "node"
+        "moduleResolution": "nodenext"
     }
 }


### PR DESCRIPTION
Fixes a couple of small bugs that I ran into.

- We were not handling the case `ArrayBuffer` properly in KV set operations.
- The responses returned by starlingMonkey were cyclic, and routers like Itty threw errors when trying to go from an error to a response. This fix now extracts the useful parts of the error and wraps them up in a simpler JS error.