### PR TITLE
ignore json files for sourcemap comments in build.mjs

### DIFF
--- a/templates/http-js/content/build.mjs
+++ b/templates/http-js/content/build.mjs
@@ -13,7 +13,9 @@ const spinPlugin = await SpinEsbuildPlugin();
 let SourceMapPlugin = {
     name: 'excludeVendorFromSourceMap',
     setup(build) {
-        build.onLoad({ filter: /node_modules/ }, args => {
+        // Only append JS-style sourceMappingURL comments to JS/TS sources.
+        // Appending this to JSON files breaks esbuild parsing.
+        build.onLoad({ filter: /node_modules\/.*\.(?:[cm]?js|tsx?)$/ }, args => {
             return {
                 contents: fs.readFileSync(args.path, 'utf8')
                     + '\n//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIiJdLCJtYXBwaW5ncyI6IkEifQ==',

--- a/templates/http-ts/content/build.mjs
+++ b/templates/http-ts/content/build.mjs
@@ -13,7 +13,9 @@ const spinPlugin = await SpinEsbuildPlugin();
 let SourceMapPlugin = {
     name: 'excludeVendorFromSourceMap',
     setup(build) {
-        build.onLoad({ filter: /node_modules/ }, args => {
+        // Only append JS-style sourceMappingURL comments to JS/TS sources.
+        // Appending this to JSON files breaks esbuild parsing.
+        build.onLoad({ filter: /node_modules\/.*\.(?:[cm]?js|tsx?)$/ }, args => {
             return {
                 contents: fs.readFileSync(args.path, 'utf8')
                     + '\n//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIiJdLCJtYXBwaW5ncyI6IkEifQ==',


### PR DESCRIPTION
Fixes the issue which arises due to trying to add sourcemap comments to JSON files as described in 
https://github.com/spinframework/spin-js-sdk/issues/406