### PR TITLE
add build tools as a peer dependency to other packages

### DIFF
--- a/packages/http-trigger/package-lock.json
+++ b/packages/http-trigger/package-lock.json
@@ -10,6 +10,9 @@
       "license": " Apache-2.0 WITH LLVM-exception",
       "devDependencies": {
         "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "@spinframework/build-tools": "^2.0.0"
       }
     },
     "node_modules/typescript": {

--- a/packages/http-trigger/package.json
+++ b/packages/http-trigger/package.json
@@ -14,6 +14,9 @@
   "devDependencies": {
     "typescript": "^6.0.3"
   },
+  "peerDependencies": {
+    "@spinframework/build-tools": "^2.0.0"
+  },
   "files": [
     "dist",
     "wit"

--- a/packages/spin-kv/package-lock.json
+++ b/packages/spin-kv/package-lock.json
@@ -10,6 +10,9 @@
       "license": " Apache-2.0 WITH LLVM-exception",
       "devDependencies": {
         "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "@spinframework/build-tools": ">=1.0.0 <3.0.0"
       }
     },
     "node_modules/typescript": {

--- a/packages/spin-kv/package.json
+++ b/packages/spin-kv/package.json
@@ -14,6 +14,9 @@
   "devDependencies": {
     "typescript": "^6.0.3"
   },
+  "peerDependencies": {
+    "@spinframework/build-tools": ">=1.0.0 <3.0.0"
+  },
   "files": [
     "dist",
     "wit"

--- a/packages/spin-llm/package-lock.json
+++ b/packages/spin-llm/package-lock.json
@@ -10,6 +10,9 @@
       "license": " Apache-2.0 WITH LLVM-exception",
       "devDependencies": {
         "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "@spinframework/build-tools": ">=1.0.0 <3.0.0"
       }
     },
     "node_modules/typescript": {

--- a/packages/spin-llm/package.json
+++ b/packages/spin-llm/package.json
@@ -14,6 +14,9 @@
   "devDependencies": {
     "typescript": "^6.0.3"
   },
+  "peerDependencies": {
+    "@spinframework/build-tools": ">=1.0.0 <3.0.0"
+  },
   "files": [
     "dist",
     "wit"

--- a/packages/spin-mqtt/package-lock.json
+++ b/packages/spin-mqtt/package-lock.json
@@ -10,6 +10,9 @@
       "license": " Apache-2.0 WITH LLVM-exception",
       "devDependencies": {
         "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "@spinframework/build-tools": ">=1.0.0 <3.0.0"
       }
     },
     "node_modules/typescript": {

--- a/packages/spin-mqtt/package.json
+++ b/packages/spin-mqtt/package.json
@@ -14,6 +14,9 @@
   "devDependencies": {
     "typescript": "^6.0.3"
   },
+  "peerDependencies": {
+    "@spinframework/build-tools": ">=1.0.0 <3.0.0"
+  },
   "files": [
     "dist",
     "wit"

--- a/packages/spin-mysql/package-lock.json
+++ b/packages/spin-mysql/package-lock.json
@@ -10,6 +10,9 @@
       "license": " Apache-2.0 WITH LLVM-exception",
       "devDependencies": {
         "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "@spinframework/build-tools": ">=1.0.0 <3.0.0"
       }
     },
     "node_modules/typescript": {

--- a/packages/spin-mysql/package.json
+++ b/packages/spin-mysql/package.json
@@ -14,6 +14,9 @@
   "devDependencies": {
     "typescript": "^6.0.3"
   },
+  "peerDependencies": {
+    "@spinframework/build-tools": ">=1.0.0 <3.0.0"
+  },
   "files": [
     "dist",
     "wit"

--- a/packages/spin-postgres/package-lock.json
+++ b/packages/spin-postgres/package-lock.json
@@ -10,6 +10,9 @@
       "license": " Apache-2.0 WITH LLVM-exception",
       "devDependencies": {
         "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "@spinframework/build-tools": ">=1.0.0 <3.0.0"
       }
     },
     "node_modules/typescript": {

--- a/packages/spin-postgres/package.json
+++ b/packages/spin-postgres/package.json
@@ -14,6 +14,9 @@
   "devDependencies": {
     "typescript": "^6.0.3"
   },
+  "peerDependencies": {
+    "@spinframework/build-tools": ">=1.0.0 <3.0.0"
+  },
   "files": [
     "dist",
     "wit"

--- a/packages/spin-postgres3/package-lock.json
+++ b/packages/spin-postgres3/package-lock.json
@@ -10,6 +10,9 @@
       "license": " Apache-2.0 WITH LLVM-exception",
       "devDependencies": {
         "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "@spinframework/build-tools": ">=1.0.0 <3.0.0"
       }
     },
     "node_modules/typescript": {

--- a/packages/spin-postgres3/package.json
+++ b/packages/spin-postgres3/package.json
@@ -14,6 +14,9 @@
   "devDependencies": {
     "typescript": "^6.0.3"
   },
+  "peerDependencies": {
+    "@spinframework/build-tools": ">=1.0.0 <3.0.0"
+  },
   "files": [
     "dist",
     "wit"

--- a/packages/spin-redis/package-lock.json
+++ b/packages/spin-redis/package-lock.json
@@ -10,6 +10,9 @@
       "license": " Apache-2.0 WITH LLVM-exception",
       "devDependencies": {
         "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "@spinframework/build-tools": ">=1.0.0 <3.0.0"
       }
     },
     "node_modules/typescript": {

--- a/packages/spin-redis/package.json
+++ b/packages/spin-redis/package.json
@@ -14,6 +14,9 @@
   "devDependencies": {
     "typescript": "^6.0.3"
   },
+  "peerDependencies": {
+    "@spinframework/build-tools": ">=1.0.0 <3.0.0"
+  },
   "files": [
     "dist",
     "wit"

--- a/packages/spin-sqlite/package-lock.json
+++ b/packages/spin-sqlite/package-lock.json
@@ -10,6 +10,9 @@
       "license": " Apache-2.0 WITH LLVM-exception",
       "devDependencies": {
         "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "@spinframework/build-tools": ">=1.0.0 <3.0.0"
       }
     },
     "node_modules/typescript": {

--- a/packages/spin-sqlite/package.json
+++ b/packages/spin-sqlite/package.json
@@ -14,6 +14,9 @@
   "devDependencies": {
     "typescript": "^6.0.3"
   },
+  "peerDependencies": {
+    "@spinframework/build-tools": ">=1.0.0 <3.0.0"
+  },
   "files": [
     "dist",
     "wit"

--- a/packages/spin-trigger-redis/package-lock.json
+++ b/packages/spin-trigger-redis/package-lock.json
@@ -10,6 +10,9 @@
       "license": " Apache-2.0 WITH LLVM-exception",
       "devDependencies": {
         "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "@spinframework/build-tools": ">=1.0.0 <3.0.0"
       }
     },
     "node_modules/typescript": {

--- a/packages/spin-trigger-redis/package.json
+++ b/packages/spin-trigger-redis/package.json
@@ -14,6 +14,9 @@
   "devDependencies": {
     "typescript": "^6.0.3"
   },
+  "peerDependencies": {
+    "@spinframework/build-tools": ">=1.0.0 <3.0.0"
+  },
   "files": [
     "dist",
     "wit"

--- a/packages/spin-variables/package-lock.json
+++ b/packages/spin-variables/package-lock.json
@@ -10,6 +10,9 @@
       "license": " Apache-2.0 WITH LLVM-exception",
       "devDependencies": {
         "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "@spinframework/build-tools": ">=1.0.0 <3.0.0"
       }
     },
     "node_modules/typescript": {

--- a/packages/spin-variables/package.json
+++ b/packages/spin-variables/package.json
@@ -14,6 +14,9 @@
   "devDependencies": {
     "typescript": "^6.0.3"
   },
+  "peerDependencies": {
+    "@spinframework/build-tools": ">=1.0.0 <3.0.0"
+  },
   "files": [
     "dist",
     "wit"

--- a/test/aot-test/package-lock.json
+++ b/test/aot-test/package-lock.json
@@ -58,6 +58,9 @@
       "license": " Apache-2.0 WITH LLVM-exception",
       "devDependencies": {
         "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "@spinframework/build-tools": "^2.0.0"
       }
     },
     "node_modules/@bytecodealliance/componentize-js": {

--- a/test/deps-test/package-lock.json
+++ b/test/deps-test/package-lock.json
@@ -58,6 +58,9 @@
       "license": " Apache-2.0 WITH LLVM-exception",
       "devDependencies": {
         "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "@spinframework/build-tools": "^2.0.0"
       }
     },
     "node_modules/@bytecodealliance/componentize-js": {

--- a/test/test-app/package-lock.json
+++ b/test/test-app/package-lock.json
@@ -59,6 +59,9 @@
       "license": " Apache-2.0 WITH LLVM-exception",
       "devDependencies": {
         "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "@spinframework/build-tools": "^2.0.0"
       }
     },
     "../../packages/spin-kv": {
@@ -67,6 +70,9 @@
       "license": " Apache-2.0 WITH LLVM-exception",
       "devDependencies": {
         "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "@spinframework/build-tools": ">=1.0.0 <3.0.0"
       }
     },
     "../../packages/spin-redis": {
@@ -84,6 +90,9 @@
       "license": " Apache-2.0 WITH LLVM-exception",
       "devDependencies": {
         "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "@spinframework/build-tools": ">=1.0.0 <3.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/test/test-empty-precompile/package-lock.json
+++ b/test/test-empty-precompile/package-lock.json
@@ -55,6 +55,9 @@
       "license": " Apache-2.0 WITH LLVM-exception",
       "devDependencies": {
         "typescript": "^6.0.3"
+      },
+      "peerDependencies": {
+        "@spinframework/build-tools": "^2.0.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/test/test.sh
+++ b/test/test.sh
@@ -5,7 +5,9 @@ cd ..
 for d in packages/*; do
     echo "Building $d"
     cd $d
-    npm install
+    # Legacy peer deps will allow us to ignore the unmet peer dependency warning for build-tools, which is not needed for building the packages themselves.
+    # We only need it when we build apps that consume said packages.
+    npm install --legacy-peer-deps
     npm audit
     npm run build
     cd -


### PR DESCRIPTION
Adds the peers peer dependencies on to all packages so that we can catch package incompatibilieis during npm install. Only the `http-trigger` is tightly coupled because of the versions of `wasi:http`.