### PR TITLE
update templates to use latest @spinframework packages

### DIFF
--- a/templates/http-js/content/build.mjs
+++ b/templates/http-js/content/build.mjs
@@ -1,6 +1,8 @@
 // build.mjs
 import { build } from 'esbuild';
 import path from 'path';
+// The @spinframework/build-tools gets installed as a peer dependency by the the other @spinframework packages
+// so we can safely import it here even if it isn't listed in the package.json.
 import { SpinEsbuildPlugin } from "@spinframework/build-tools/plugins/esbuild/index.js";
 import fs from 'fs';
 

--- a/templates/http-js/content/package.json
+++ b/templates/http-js/content/package.json
@@ -13,7 +13,8 @@
   "license": "ISC",
   "devDependencies": {
     "mkdirp": "^3.0.1",
-    "esbuild": "^0.25.8"
+    "esbuild": "^0.25.8",
+    "@spinframework/build-tools": "^2.0.0"
   },
   "dependencies": {
     {%- case http-router -%}
@@ -22,7 +23,6 @@
     {% when "itty" %}
     "itty-router": "^5.0.18",
     {%- endcase %}
-    "@spinframework/build-tools": "^1.0.4",
-    "@spinframework/wasi-http-proxy": "^1.0.0"
+    "@spinframework/wasi-http-proxy": "^2.0.0"
   }
 }

--- a/templates/http-js/content/package.json
+++ b/templates/http-js/content/package.json
@@ -13,8 +13,7 @@
   "license": "ISC",
   "devDependencies": {
     "mkdirp": "^3.0.1",
-    "esbuild": "^0.25.8",
-    "@spinframework/build-tools": "^2.0.0"
+    "esbuild": "^0.25.8"
   },
   "dependencies": {
     {%- case http-router -%}

--- a/templates/http-ts/content/build.mjs
+++ b/templates/http-ts/content/build.mjs
@@ -1,6 +1,8 @@
 // build.mjs
 import { build } from 'esbuild';
 import path from 'path';
+// The @spinframework/build-tools gets installed as a peer dependency by the the other @spinframework packages
+// so we can safely import it here even if it isn't listed in the package.json.
 import { SpinEsbuildPlugin } from "@spinframework/build-tools/plugins/esbuild/index.js";
 import fs from 'fs';
 

--- a/templates/http-ts/content/package.json
+++ b/templates/http-ts/content/package.json
@@ -15,7 +15,8 @@
     "mkdirp": "^3.0.1",
     "ts-loader": "^9.4.1",
     "typescript": "^4.8.4",
-    "esbuild": "^0.25.8"
+    "esbuild": "^0.25.8",
+    "@spinframework/build-tools": "^2.0.0"
   },
   "dependencies": {
     {%- case http-router -%}
@@ -24,7 +25,6 @@
     {% when "itty" %}
     "itty-router": "^5.0.18",
     {%- endcase %}
-    "@spinframework/build-tools": "^1.0.4",
-    "@spinframework/wasi-http-proxy": "^1.0.0"
+    "@spinframework/wasi-http-proxy": "^2.0.0"
   }
 }

--- a/templates/http-ts/content/package.json
+++ b/templates/http-ts/content/package.json
@@ -15,8 +15,7 @@
     "mkdirp": "^3.0.1",
     "ts-loader": "^9.4.1",
     "typescript": "^4.8.4",
-    "esbuild": "^0.25.8",
-    "@spinframework/build-tools": "^2.0.0"
+    "esbuild": "^0.25.8"
   },
   "dependencies": {
     {%- case http-router -%}


### PR DESCRIPTION
`build-tools` can now be moved into the devDependency because we no longer need wasi:cli (the bug in the starlingmonkey debugger that made this needed has now been fixed).